### PR TITLE
Handle remote power actions gracefully and remove GitLab UI

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
   <meta charset="utf-8">
-  <title>PXE Dashboard – Сфера Телеком</title>
+  <title>PXE Dashboard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <!-- CodeMirror CSS -->
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.2/theme/dracula.min.css" />
   <!-- Шрифт Fira Code -->
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
   <style>
     :root {
       --accent: #1976d2;
@@ -21,7 +22,6 @@
       --grey: #9e9e9e;
       --danger: #ef5350;
       --orange: #ffa726;
-      --git: #6f42c1;
       --portainer: #139eca;
       --wol: #4caf50;
       --shutdown: #607d8b;
@@ -40,7 +40,6 @@
         --grey: #757575;
         --danger: #c62828;
         --orange: #ff9800;
-        --git: #8a63d2;
         --portainer: #15a8e0;
         --wol: #66bb6a;
         --shutdown: #78909c;
@@ -57,18 +56,21 @@
       transition: background 0.3s, color 0.3s;
     }
     body {
-      font-family: "Segoe UI", sans-serif;
+      font-family: "Inter", "Segoe UI", sans-serif;
+      line-height: 1.6;
       background: var(--bg);
       color: var(--text);
     }
     header {
-      background: linear-gradient(135deg, var(--accent), #1e88e5);
+      background: linear-gradient(135deg, var(--accent), #2196f3);
       color: #fff;
       padding: 14px 28px;
       display: flex;
       align-items: center;
       justify-content: space-between;
       box-shadow: var(--header-shadow);
+      border-bottom-left-radius: 8px;
+      border-bottom-right-radius: 8px;
     }
     .btn,
     .btn-reboot,
@@ -80,7 +82,7 @@
     .btn-logtail {
       border: none;
       padding: 6px 12px;
-      border-radius: 6px;
+      border-radius: 8px;
       color: #fff;
       cursor: pointer;
       font-weight: 500;
@@ -90,6 +92,7 @@
       text-decoration: none;
       font-size: 0.9em;
       margin-top: 4px;
+      transition: background-color 0.2s, transform 0.2s;
     }
     .btn,
     .btn-reboot,
@@ -100,18 +103,13 @@
       margin-top: 0;
     }
     .btn { background: var(--accent); }
-    .btn:hover { background: #1565c0; }
+    .btn:hover { background: #1565c0; transform: translateY(-1px); }
     .btn-danger { background: var(--danger); }
     .btn-danger:hover { background: #d32f2f; }
     .btn-reboot { background: var(--orange); padding: 4px 8px; font-size: 0.85em; }
     .btn-reboot:hover { background: #fb8c00; }
     .btn-semaphore { background: #4caf50; }
     .btn-semaphore:hover { background: #388e3c; }
-    .btn-git-push { background: var(--git); }
-    .btn-git-push:hover { background: #5a32a3; }
-    @media (prefers-color-scheme: dark) {
-      .btn-git-push:hover { background: #7a52c2; }
-    }
     .btn-portainer { background: var(--portainer); padding: 6px 10px; font-size: 0.85em; }
     .btn-portainer:hover { background: #0f7ba5; }
     @media (prefers-color-scheme: dark) {
@@ -133,8 +131,6 @@
     .btn-logtail { background: var(--logtail); padding: 6px 10px; font-size: 0.85em; }
     .btn-logtail:hover { background: #7b1fa2; }
     .btn-logtail i { font-size: 0.9em; }
-    .btn-gitlab { background: #f34f29 !important; }
-    .btn-gitlab:hover { background: #cc4125 !important; }
     .container { padding: 24px; }
     table {
       width: 100%;
@@ -146,9 +142,16 @@
       box-shadow: var(--table-shadow);
       font-size: 0.95em;
     }
+    thead th {
+      background: var(--accent);
+      color: #fff;
+    }
     th, td { padding: 14px 18px; text-align: left; vertical-align: middle; }
     tr:not(:last-child) td { border-bottom: 1px solid var(--border); }
-    tr:hover { background-color: rgba(0,0,0,0.05); }
+    tr:hover { background-color: rgba(0,0,0,0.04); }
+    @media (prefers-color-scheme: dark) {
+      tr:hover { background-color: rgba(255,255,255,0.05); }
+    }
     .status { font-weight: 600; display: flex; align-items: center; gap: 6px; }
     .status.online { color: var(--green); }
     .status.offline { color: var(--grey); }
@@ -201,15 +204,9 @@
         <a class="btn btn-semaphore" href="http://10.19.1.90:3000" target="_blank" rel="noopener noreferrer">
           <i class="fa fa-external-link-alt"></i> Semaphore
         </a>
-        <a class="btn btn-gitlab" href="http://10.19.1.20/Automatization/ansible-semaphore" target="_blank" rel="noopener noreferrer" title="GitLab Ansible">
-          <i class="fab fa-gitlab"></i> GitLab
-        </a>
         <a class="btn btn-logtail" href="http://10.19.1.90:5004/logtail.html" target="_blank" rel="noopener noreferrer">
           <i class="fas fa-file-alt"></i> Logtail
         </a>
-        <button class="btn btn-git-push" id="git-commit-push">
-          <i class="fab fa-git-alt"></i> Commit & Push
-        </button>
       </div>
       <div class="divider"></div>
       <div class="header-group">
@@ -228,7 +225,6 @@
       <div class="semaphore-status" id="semaphore-status">
         <i class="fas fa-sync fa-spin"></i> Загрузка статуса...
       </div>
-      <span style="font-weight:bold; opacity: 0.9;">"Сфера Телеком"</span>
     </div>
   </header>
   <div id="ansible-panel" style="margin: 24px 0; padding: 16px; border-radius: 8px; background: var(--bg); border: 1px solid var(--border); display: none;">
@@ -608,20 +604,6 @@
         }
       }
     });
-    document.getElementById('git-commit-push').onclick = async () => {
-      if (!confirm('Вы уверены, что хотите отправить изменения в Git-репозиторий?')) return;
-      try {
-        const res = await fetch('/api/git/commit-push', { method: 'POST' });
-        const data = await res.json();
-        if (res.ok) {
-          alert(data.msg || 'Изменения успешно отправлены в репозиторий.');
-        } else {
-          alert('Ошибка: ' + (data.msg || 'Неизвестная ошибка'));
-        }
-      } catch (e) {
-        alert('Ошибка: ' + e.message);
-      }
-    };
     overlay.onclick = () => modals.forEach(closeModal);
 
     // ==== Интеграция с Semaphore API ====


### PR DESCRIPTION
## Summary
- Gracefully handle SSH errors and timeouts when rebooting or shutting down hosts
- Drop GitLab links and commit/push endpoint
- Refresh dashboard styling with Inter font and cleaner header/table look

## Testing
- `python -m py_compile app.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689eda61ab808327ba6846863ac86f1f