### PR TITLE
Add preseed configurator UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,7 @@ from flask import Flask, render_template, request, jsonify, abort
 
 # Blueprint с функциями просмотра журналов
 from logtail import logtail_bp
+from preseed import preseed_bp
 
 # ==== Конфигурация ====
 # Пути к основным файлам и настройкам приложения
@@ -74,6 +75,7 @@ app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 3600
 
 # Регистрируем Blueprint логов, чтобы панель логов работала на том же хосте
 app.register_blueprint(logtail_bp)
+app.register_blueprint(preseed_bp, url_prefix='/preseed')
 
 # ==== Вспомогательные функции ====
 def get_db():

--- a/preseed.py
+++ b/preseed.py
@@ -1,0 +1,557 @@
+from flask import Blueprint, render_template, request, send_file, jsonify
+import io
+import re
+from datetime import datetime
+import json
+from pathlib import Path
+
+preseed_bp = Blueprint('preseed', __name__, template_folder='templates')
+
+TEMPLATES_FILE = Path('preseed_templates.json')
+HISTORY_FILE = Path('preseed_history.json')
+
+def load_templates():
+    if not TEMPLATES_FILE.exists():
+        return []
+    try:
+        with open(TEMPLATES_FILE) as f:
+            return json.load(f).get('шаблоны', [])
+    except Exception:
+        return []
+
+def save_templates(templates):
+    with open(TEMPLATES_FILE, 'w') as f:
+        json.dump({'шаблоны': templates}, f, indent=2)
+
+def load_history():
+    if not HISTORY_FILE.exists():
+        return []
+    try:
+        with open(HISTORY_FILE, 'r') as f:
+            return json.load(f)
+    except Exception:
+        return []
+
+def save_to_history(data, preseed):
+    history = load_history()
+    history.append({
+        'timestamp': datetime.now().isoformat(),
+        'params': data,
+        'preseed_preview': preseed[:500] + '...' if len(preseed) > 500 else preseed
+    })
+    with open(HISTORY_FILE, 'w') as f:
+        json.dump(history[-20:], f, indent=2)
+
+@preseed_bp.route('/')
+def index():
+    return render_template('preseed/index.html')
+
+@preseed_bp.route('/api/templates')
+def api_templates():
+    return jsonify([{'name': t['name']} for t in load_templates()])
+
+@preseed_bp.route('/api/template/<name>')
+def api_template(name):
+    for template in load_templates():
+        if template['name'] == name:
+            return jsonify(template['data'])
+    return "Шаблон не найден", 404
+
+@preseed_bp.route('/api/save-template', methods=['POST'])
+def api_save_template():
+    try:
+        data = request.get_json()
+        if not data or 'name' not in data or 'data' not in data:
+            return "Некорректные данные", 400
+        templates = load_templates()
+        if any(t['name'] == data['name'] for t in templates):
+            return "Шаблон с таким именем уже существует", 400
+        templates.append({'name': data['name'], 'data': data['data']})
+        save_templates(templates)
+        return "OK", 200
+    except Exception as e:
+        return f"Ошибка: {str(e)}", 500
+
+@preseed_bp.route('/api/history')
+def api_history():
+    return jsonify(load_history())
+
+@preseed_bp.route('/preview', methods=['POST'])
+@preseed_bp.route('/generate', methods=['POST'])
+def preview_or_generate():
+    try:
+        raid_level = request.form.get('raid_level', '1')
+        disk_count = int(request.form['disk_count'])
+        hot_spare = request.form.get('hot_spare') == 'on'
+        min_disks = 1 if raid_level == '0' else 2
+        if hot_spare and raid_level == '1':
+            min_disks += 1
+        if disk_count < min_disks:
+            return (
+                f"Ошибка: Для RAID-{raid_level}{' с hot spare' if hot_spare else ''} требуется минимум {min_disks} дисков",
+                400,
+            )
+        partitions = {}
+        for part in ['efi', 'boot', 'root', 'home', 'var', 'swap']:
+            size = request.form[f'{part}_size'].strip()
+            if not re.match(r'^\d+[kKmMgG]?$', size):
+                return (
+                    f"Ошибка: Некорректный размер для {part} ({size}). Примеры: 512, 1G, 2048M",
+                    400,
+                )
+            if part == 'efi' and int(re.sub(r'[^\d]', '', size)) < 100:
+                return "Ошибка: Размер EFI раздела должен быть не менее 100M", 400
+            partitions[part] = size
+        if len(request.form['root_password']) < 8:
+            return "Ошибка: Пароль root должен быть не менее 8 символов", 400
+        if request.form.get('mirror_mode') == 'custom':
+            mirrors = []
+            for i in range(1, 6):
+                url = request.form.get(f'mirror_url_{i}', '').strip()
+                if url:
+                    mirrors.append(url)
+            if not mirrors:
+                return "Ошибка: Укажите хотя бы одно зеркало", 400
+        if request.form.get('enable_ipxe') == 'on':
+            ipxe_url = request.form.get('ipxe_url', '').strip()
+            if not ipxe_url:
+                return "Ошибка: Укажите URL сервера регистрации", 400
+            if not ipxe_url.startswith(('http://', 'https://')):
+                return "Ошибка: URL должен начинаться с http:// или https://", 400
+            if (
+                request.form.get('register_dhcp') != 'on'
+                and request.form.get('register_disk') != 'on'
+            ):
+                return "Ошибка: Выберите хотя бы один этап регистрации", 400
+        net_mode = request.form.get('net_mode', 'dhcp')
+        if net_mode == 'static':
+            required_fields = ['net_ip', 'net_netmask', 'net_gateway', 'net_dns']
+            for field in required_fields:
+                if not request.form.get(field):
+                    return f"Ошибка: Требуется поле '{field}' для статической сети", 400
+        data = {
+            'disk_count': disk_count,
+            'raid_level': raid_level,
+            'hot_spare': hot_spare,
+            'partitions': [partitions[p] for p in ['efi', 'boot', 'root', 'home', 'var', 'swap']],
+            'hostname': request.form['hostname'],
+            'root_password': request.form['root_password'],
+            'username': request.form['username'],
+            'user_password': request.form['user_password'],
+            'mirror_host': request.form['mirror_host'],
+            'mirror_mode': request.form.get('mirror_mode', 'default'),
+            'timezone': request.form['timezone'],
+            'locale': request.form['locale'],
+            'net_mode': net_mode,
+            'net_ip': request.form.get('net_ip', ''),
+            'net_netmask': request.form.get('net_netmask', ''),
+            'net_gateway': request.form.get('net_gateway', ''),
+            'net_dns': request.form.get('net_dns', ''),
+            'enable_ipxe': request.form.get('enable_ipxe', 'off'),
+            'ipxe_url': request.form.get('ipxe_url', ''),
+            'register_dhcp': request.form.get('register_dhcp', 'off'),
+            'register_disk': request.form.get('register_disk', 'off'),
+            'enable_ansible': request.form.get('enable_ansible', 'off'),
+            'ansible_script': request.form.get('ansible_script', 'http://10.19.1.104:8081/repository/artifacts-local/other/config/ansible-register.sh'),
+            'show_ip': request.form.get('show_ip', 'off'),
+            'fix_hostname': request.form.get('fix_hostname', 'on'),
+            'disable_video': request.form.get('disable_video', 'off'),
+            'enable_font': request.form.get('enable_font', 'on'),
+            'font_face': request.form.get('font_face', 'Terminus'),
+            'font_size': request.form.get('font_size', '16x32'),
+            'install_base_packages': request.form.get('install_base_packages', 'on'),
+            'enable_root_ssh': request.form.get('enable_root_ssh', 'on'),
+            'disable_sound': request.form.get('disable_sound', 'on'),
+            'extended_registration': request.form.get('extended_registration', 'on'),
+        }
+        if data['mirror_mode'] == 'custom':
+            data['mirrors'] = []
+            for i in range(1, 6):
+                url = request.form.get(f'mirror_url_{i}', '').strip()
+                if url:
+                    data['mirrors'].append(url)
+        preseed = generate_preseed(data)
+        if request.path.endswith('generate'):
+            save_to_history(data, preseed)
+            return send_file(
+                io.BytesIO(preseed.encode('utf-8')),
+                mimetype='text/plain',
+                as_attachment=True,
+                download_name=f"debian12-preseed-{data['hostname']}.cfg",
+            )
+        return preseed
+    except ValueError:
+        return "Ошибка: Некорректные числовые значения", 400
+    except Exception as e:
+        return f"Критическая ошибка: {str(e)}", 500
+
+def generate_preseed(data):
+    disks = [f"/dev/sd{chr(97 + i)}" for i in range(data['disk_count'])]
+    disk_string = ' '.join(disks)
+
+    def raid_paths(part_num):
+        return '#'.join([f"{disk}{part_num}" for disk in disks])
+
+    def convert_size(size, default_unit='M'):
+        size = str(size).strip().upper()
+        if size.endswith('G'):
+            return str(int(float(size[:-1]) * 1024))
+        elif size.endswith('M'):
+            return size[:-1]
+        elif size.endswith('K'):
+            return str(int(size[:-1]) / 1024)
+        return size
+
+    efi_size = convert_size(data['partitions'][0], 'M')
+    boot_size = convert_size(data['partitions'][1], 'M')
+    root_size = convert_size(data['partitions'][2], 'M')
+    home_size = convert_size(data['partitions'][3], 'M')
+    var_size = convert_size(data['partitions'][4], 'M')
+    swap_size = convert_size(data['partitions'][5], 'M')
+    for size in [efi_size, boot_size, root_size, home_size, var_size, swap_size]:
+        if int(size) <= 0:
+            raise ValueError("Размер раздела должен быть положительным числом")
+
+    raid_level = data['raid_level']
+    spare_disks = 1 if data['hot_spare'] and raid_level == '1' else 0
+
+    expert_recipe = f"""\
+      multiraid :: \\
+        {efi_size} {efi_size} {efi_size} fat32 \\
+          $primary{{ }} \\
+          $bootable{{ }} \\
+          method{{ efi }} \\
+          format{{ }} \\
+        . \\
+        {boot_size} {boot_size} {boot_size} raid \\
+          $primary{{ }} \\
+          method{{ raid }} \\
+        . \\
+        {root_size} {root_size} {root_size} raid \\
+          $primary{{ }} \\
+          method{{ raid }} \\
+        . \\
+        {home_size} {home_size} {home_size} raid \\
+          $primary{{ }} \\
+          method{{ raid }} \\
+        . \\
+        {var_size} {var_size} {var_size} raid \\
+          $primary{{ }} \\
+          method{{ raid }} \\
+        . \\
+        {swap_size} {swap_size} {swap_size} linux-swap \\
+          method{{ swap }} \\
+          format{{ }} \\
+        .
+    """
+
+    raid_recipe = f"""\
+      {raid_level} {data['disk_count']} {spare_disks} ext4 /boot {raid_paths('2')} \\
+      . \\
+      {raid_level} {data['disk_count']} {spare_disks} ext4 / {raid_paths('3')} \\
+      . \\
+      {raid_level} {data['disk_count']} {spare_disks} ext4 /home {raid_paths('4')} \\
+      . \\
+      {raid_level} {data['disk_count']} {spare_disks} ext4 /var {raid_paths('5')} \\
+      .
+    """
+
+    preseed_lines = [
+        "# =============================!===============================",
+        "# Debian 12 (bookworm) — автоматическая установка",
+        f"# UEFI + RAID-{raid_level} ({data['disk_count']}×SSD/HDD), EFI без RAID, /boot RAID-{raid_level}",
+        f"# Сгенерировано: {datetime.now().strftime('%Y-%m-%d %H:%M')}",
+        "# ============================================================",
+        ""
+    ]
+
+    if data.get('enable_ipxe') == 'on' and data.get('register_dhcp') == 'on':
+        preseed_lines.extend([
+            "",
+            "### 🛰️  ЭТАП 1: РЕГИСТРАЦИЯ ПОСЛЕ DHCP",
+            "### ============================================================",
+            "",
+        ])
+        preseed_lines.extend([
+            f"d-i preseed/early_command string \\",
+            "  sh -c 'iface=$(ip route | awk \"/default/ {print $5; exit}\"); \\",
+            "  mac=$(cat /sys/class/net/$iface/address); \\",
+            "  ip_addr=$(ip -4 -o addr show $iface | awk \"{split($4,a,\"/\"); print a[1]}\"); \\",
+            "  mkdir -p /var/log/installer; \\",
+            "  exec > /var/log/installer/syslog.$mac 2>&1; \\",
+            f"  wget -q --post-data \"mac=$mac&ip=$ip_addr&stage=dhcp\" \"{data['ipxe_url']}\" || true'",
+        ])
+    if data['net_mode'] == 'static':
+        preseed_lines.extend([
+            "",
+            "### ============================================================",
+            "### 🌐  СЕТЕВАЯ КОНФИГУРАЦИЯ (статическая)",
+            "### ============================================================",
+            "",
+            "d-i netcfg/disable_autoconfig boolean true",
+            "d-i netcfg/dhcp_timeout string 60",
+            f"d-i netcfg/get_hostname string {data['hostname']}",
+            "d-i netcfg/get_domain string local",
+            "d-i netcfg/wireless_wep string",
+            f"d-i netcfg/ipaddress string {data['net_ip']}",
+            f"d-i netcfg/netmask string {data['net_netmask']}",
+            f"d-i netcfg/gateway string {data['net_gateway']}",
+            f"d-i netcfg/dns string {data['net_dns']}",
+            "d-i netcfg/confirm_static boolean true",
+            ""
+        ])
+    else:
+        preseed_lines.extend([
+            "",
+            "### ============================================================",
+            "### 🌐  СЕТЕВАЯ КОНФИГУРАЦИЯ (DHCP)",
+            "### ============================================================",
+            "",
+            "d-i netcfg/choose_interface select auto",
+            f"d-i netcfg/get_hostname string {data['hostname']}",
+            "d-i netcfg/wireless_wep string",
+            ""
+        ])
+
+    preseed_lines.extend([
+        "",
+        "### ============================================================",
+        "### ⌨️  ОСНОВНЫЕ НАСТРОЙКИ (Locale, Keyboard, Installer)",
+        "### ============================================================",
+        "",
+        f"d-i debian-installer/locale string {data['locale']}",
+        "d-i console-setup/ask_detect boolean false",
+        "d-i keyboard-configuration/xkb-keymap select us,ru",
+        "d-i debian-installer/quiet boolean true",
+        "d-i preseed/quiet boolean true",
+        ""
+    ])
+
+    if data['mirror_mode'] == 'default':
+        preseed_lines.extend([
+            "",
+            "### ============================================================",
+            "### 📦  ЭТАП 2: ЗЕРКАЛА APT",
+            "### ============================================================",
+            "",
+            "d-i mirror/country string manual",
+            f"d-i mirror/http/hostname string {data['mirror_host']}",
+            "d-i mirror/http/directory string /repository/debian-bookworm-proxy",
+            "d-i mirror/http/proxy string",
+            ""
+        ])
+    else:
+        preseed_lines.extend([
+            "",
+            "### ============================================================",
+            "### 📦  ЭТАП 2: КАСТОМНЫЕ ЗЕРКАЛА APT",
+            "### ============================================================",
+            "",
+            "d-i apt-setup/use_mirror boolean false",
+            "d-i apt-setup/services-select multiselect security, volatile",
+            "d-i apt-setup/security_host string security.debian.org",
+            ""
+        ])
+
+    preseed_lines.extend([
+        "",
+        "### ============================================================",
+        f"### 💽  ЭТАП 3: РАЗМЕТКА ДИСКОВ (RAID-{raid_level})",
+        "### ============================================================",
+        "",
+        f"d-i partman-auto/disk string {disk_string}",
+        "d-i partman-auto/method string raid",
+        "d-i partman-lvm/device_remove_lvm boolean true",
+        "d-i partman-md/device_remove_md boolean true",
+        "d-i partman-auto/expert_recipe string \\",
+        expert_recipe.strip(),
+        "",
+        "d-i partman-auto-raid/recipe string \\",
+        raid_recipe.strip(),
+        ""
+    ])
+
+    preseed_lines.extend([
+        "",
+        "### ============================================================",
+        "### 🧨  ЭТАП 4: ПОДТВЕРЖДЕНИЕ РАЗМЕТКИ",
+        "### ============================================================",
+        "",
+        "d-i partman-partitioning/confirm_write_new_label boolean true",
+        "d-i partman/choose_partition select finish",
+        "d-i partman/confirm boolean true",
+        "d-i partman/confirm_nooverwrite boolean true",
+        "d-i partman-md/confirm boolean true",
+        "d-i partman-md/confirm_nooverwrite boolean true",
+        "",
+        "### ============================================================",
+        "### 👤  ЭТАП 5: УЧЁТНЫЕ ЗАПИСИ",
+        "### ============================================================",
+        "",
+        f"d-i passwd/root-password password {data['root_password']}",
+        f"d-i passwd/root-password-again password {data['root_password']}",
+        f"d-i passwd/user-fullname string {data['username']}",
+        f"d-i passwd/username string {data['username']}",
+        f"d-i passwd/user-password password {data['user_password']}",
+        f"d-i passwd/user-password-again password {data['user_password']}",
+        "d-i user-setup/allow-password-weak boolean true",
+        "",
+        "### ============================================================",
+        "### 🛠️  ЭТАП 6: ПАКЕТЫ И СЕРВИСЫ",
+        "### ============================================================",
+        "",
+        "tasksel tasksel/first multiselect standard, ssh-server",
+        "d-i pkgsel/include string openssh-server mc dosfstools iproute2 curl wget",
+        "d-i pkgsel/upgrade select none",
+        "d-i pkgsel/update-policy select none",
+        "",
+        "### ============================================================",
+        "### 🕒  ЭТАП 7: ЛОКАЛИЗАЦИЯ ВРЕМЕНИ",
+        "### ============================================================",
+        "",
+        "d-i clock-setup/utc boolean true",
+        f"d-i time/zone string {data['timezone']}",
+        "",
+        "### ============================================================",
+        "### 🧱  ЭТАП 8: УСТАНОВКА GRUB",
+        "### ============================================================",
+        "",
+        "d-i grub-installer/only_debian boolean true",
+        f"d-i grub-installer/bootdev string {disks[0]}",
+        "",
+        "### ============================================================",
+        "### 📵  ЭТАП 9: ПРОШИВКИ",
+        "### ============================================================",
+        "",
+        "d-i hw-detect/load_firmware boolean false",
+        "",
+        "### ============================================================",
+        "### 🔧  ЭТАП 10: LATE_COMMAND (Post-install)",
+        "### ============================================================",
+        "",
+        "d-i preseed/late_command string \\",
+    ])
+
+    late_lines = []
+    if data.get('register_disk') == 'on':
+        late_lines.extend([
+            "# === 📡 Регистрация хоста на сервере === \\",
+            "MAC=$(cat /sys/class/net/$(ip route|awk '/default/{print $5}')/address); \\",
+            "IP=$(ip -4 -o addr show $(ip route|awk '/default/{print $5}') | awk '{split($4,a,\"/\"); print a[1]}'); \\",
+            f"HOST={data['hostname']}; \\",
+        ])
+        if data.get('extended_registration') == 'on':
+            late_lines.extend([
+                "echo \"Disk info for $HOST ($IP):\" > /tmp/disk_info.$MAC; \\",
+                "parted -l >> /tmp/disk_info.$MAC; \\",
+                "lsblk >> /tmp/disk_info.$MAC; \\",
+                "df -h >> /tmp/disk_info.$MAC; \\",
+                f"wget -q --post-data \"mac=$MAC&ip=$IP&hostname=$HOST&stage=disk_partitioned&details=$(cat /tmp/disk_info.$MAC | base64)\" \"{data['ipxe_url']}\" || true; \\",
+            ])
+        else:
+            late_lines.extend([
+                f"wget -q --post-data \"mac=$MAC&ip=$IP&hostname=$HOST&stage=disk_partitioned\" \"{data['ipxe_url']}\" || true; \\",
+            ])
+
+    if data.get('install_base_packages') == 'on':
+        late_lines.extend([
+            "",
+            "# === ⚙️ Установка базовых пакетов + шрифт === \\",
+            "in-target apt-get update ; \\",
+            "in-target apt-get install -y wget curl python3 python3-pip console-setup fonts-dejavu-core; \\",
+        ])
+
+    if data.get('enable_root_ssh') == 'on':
+        late_lines.extend([
+            "",
+            "# === 🔐 Разрешить root-доступ по SSH === \\",
+            "echo 'PermitRootLogin yes' > /target/etc/ssh/sshd_config.d/perms.conf; \\",
+        ])
+
+    if data.get('disable_sound') == 'on':
+        late_lines.extend([
+            "",
+            "# === 🔇 Отключение звука === \\",
+            "echo 'blacklist snd_hda_intel' > /target/etc/modprobe.d/disable-hdaudio.conf; \\",
+            "in-target update-grub; \\",
+            "in-target update-initramfs -u; \\",
+        ])
+
+    late_lines.extend([
+        "",
+        "# === 📚 APT-источники === \\",
+        "echo '# Основной репозиторий' > /target/etc/apt/sources.list; \\",
+    ])
+    if data["mirror_mode"] == "default":
+        late_lines.extend([
+            f"echo 'deb {data['mirror_host']}/repository/debian-bookworm-proxy bookworm main contrib non-free non-free-firmware' >> /target/etc/apt/sources.list; \\",
+            f"echo 'deb {data['mirror_host']}/repository/debian-bookworm-proxy bookworm-updates main contrib non-free non-free-firmware' >> /target/etc/apt/sources.list; \\",
+            f"echo 'deb {data['mirror_host']}/repository/debian-security-proxy bookworm-security main contrib non-free non-free-firmware' >> /target/etc/apt/sources.list; \\",
+            "in-target apt update; \\",
+        ])
+    else:
+        for url in data.get("mirrors", []):
+            late_lines.append(f"echo \"{url}\" >> /target/etc/apt/sources.list; \\")
+        late_lines.append("in-target apt update; \\")
+
+    if data.get('show_ip') == 'on':
+        late_lines.extend([
+            "",
+            "# === 📟 IP в bash.bashrc === \\",
+            "echo '# Ваш IP (физический интерфейс):' >> /target/etc/bash.bashrc; \\",
+            "echo \"ip -4 -o addr show scope global | awk '{print \\$4}' | cut -d/ -f1 | head -n1\" >> /target/etc/bash.bashrc; \\",
+            "echo '' >> /target/etc/bash.bashrc; \\",
+        ])
+
+    if data.get('enable_ansible') == 'on':
+        late_lines.extend([
+            "",
+            "# === 🤖 Регистрация в Ansible === \\",
+            f"wget -O /target/root/ansible-register.sh \"{data['ansible_script']}\" ; \\",
+            "chmod +x /target/root/ansible-register.sh; \\",
+            "echo '#!/bin/bash' > /target/etc/rc.local; \\",
+            "echo 'sleep 30' >> /target/etc/rc.local; \\",
+            "echo '/root/ansible-register.sh &' >> /target/etc/rc.local; \\",
+            "echo 'exit 0' >> /target/etc/rc.local; \\",
+            "chmod +x /target/etc/rc.local; \\",
+            "in-target systemctl enable rc-local; \\",
+        ])
+
+    if data.get('fix_hostname') == 'on':
+        late_lines.extend([
+            "",
+            "# === 🤖 Настройка hostname === \\",
+            f"echo {data['hostname']} > /target/etc/hostname; \\",
+            f"echo \"127.0.1.1 {data['hostname']}.localdomain {data['hostname']}\" >> /target/etc/hosts; \\",
+        ])
+
+    if data.get('disable_video') == 'on':
+        late_lines.extend([
+            "",
+            "# === 🖥️ Отключение видеодрайвера === \\",
+            "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"quiet nomodeset i915.modeset=0\"' >> /target/etc/default/grub; \\",
+            "echo 'blacklist i915' > /target/etc/modprobe.d/disable-i915.conf; \\",
+            "echo 'blacklist intel_guc' >> /target/etc/modprobe.d/disable-i915.conf; \\",
+            "in-target update-grub; \\",
+            "in-target update-initramfs -u; \\",
+        ])
+
+    if data.get('enable_font') == 'on':
+        late_lines.extend([
+            "",
+            "# === 😍 Красивый шрифт в TTY === \\",
+            f"echo 'FONTFACE=\"{data['font_face']}\"' > /target/etc/default/console-setup; \\",
+            f"echo 'FONTSIZE=\"{data['font_size']}\"' >> /target/etc/default/console-setup; \\",
+            "echo 'FONT=' >> /target/etc/default/console-setup; \\",
+            "echo 'VIDEOMODE=' >> /target/etc/default/console-setup; \\",
+            "in-target setupcon; \\",
+        ])
+
+    late_lines.extend([
+        "",
+        "### 🚀 Завершение установки",
+        "d-i finish-install/reboot_in_progress note",
+    ])
+
+    preseed_lines.extend(late_lines)
+    return '\n'.join(preseed_lines)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -30,6 +30,7 @@
       <div class="divider"></div>
       <div class="header-group">
         <button class="btn" id="edit-preseed"><i class="fa fa-edit"></i> Preseed</button>
+        <a class="btn" href="{{ url_for('preseed.index') }}"><i class="fa fa-wrench"></i> Preseed Configurator</a>
         <button class="btn" id="edit-dnsmasq"><i class="fa fa-network-wired"></i> DHCP / iPXE</button>
         <button class="btn" id="edit-ipxe"><i class="fa fa-code"></i> iPXE</button>
       </div>

--- a/templates/preseed/index.html
+++ b/templates/preseed/index.html
@@ -1,0 +1,1452 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Debian 12 Preseed Конструктор</title>
+    <style>
+        :root {
+            --primary: #2c3e50;
+            --secondary: #3498db;
+            --success: #27ae60;
+            --warning: #e67e22;
+            --danger: #e74c3c;
+            --light: #ecf0f1;
+            --dark: #34495e;
+        }
+        * {
+            box-sizing: border-box;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        }
+        body {
+            background: #f5f7fa;
+            color: #333;
+            line-height: 1.6;
+            padding: 0;
+            margin: 0;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            padding: 20px;
+            border-radius: 0;
+            box-shadow: 0 0 10px rgba(0,0,0,0.05);
+        }
+        header {
+            text-align: center;
+            padding: 20px 0;
+            border-bottom: 1px solid var(--light);
+            margin-bottom: 20px;
+        }
+        h1 {
+            color: var(--primary);
+            margin: 0;
+            font-size: 1.8em;
+        }
+        .setup-wizard {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        .wizard-steps {
+            display: flex;
+            border-bottom: 1px solid var(--light);
+            padding-bottom: 15px;
+        }
+        .step {
+            flex: 1;
+            text-align: center;
+            position: relative;
+            cursor: pointer;
+            padding: 10px 0;
+        }
+        .step-number {
+            display: inline-flex;
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            background: var(--light);
+            align-items: center;
+            justify-content: center;
+            margin-right: 8px;
+            font-weight: bold;
+        }
+        .step.active .step-number {
+            background: var(--secondary);
+            color: white;
+        }
+        .step.completed .step-number {
+            background: var(--success);
+            color: white;
+        }
+        .step-label {
+            font-size: 0.9em;
+            color: var(--dark);
+        }
+        .step.active .step-label {
+            font-weight: bold;
+            color: var(--primary);
+        }
+        .step-line {
+            position: absolute;
+            bottom: 14px;
+            left: 50%;
+            width: 100%;
+            height: 2px;
+            background: var(--light);
+            z-index: -1;
+        }
+        .step:last-child .step-line {
+            display: none;
+        }
+        .step.active .step-line {
+            background: var(--secondary);
+        }
+        .config-card {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+            overflow: hidden;
+        }
+        .card-header {
+            background: var(--primary);
+            color: white;
+            padding: 15px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .card-content {
+            padding: 20px;
+        }
+        .form-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+        }
+        .section {
+            margin-bottom: 20px;
+        }
+        h2 {
+            color: var(--primary);
+            margin-top: 0;
+            font-size: 1.3em;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .form-group {
+            margin-bottom: 15px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: 600;
+            color: #555;
+        }
+        input, select, textarea {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 16px;
+        }
+        input:focus, select:focus, textarea:focus {
+            outline: none;
+            border-color: var(--secondary);
+            box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+        }
+        .hint {
+            font-size: 0.85em;
+            color: #777;
+            margin-top: 5px;
+            display: flex;
+            align-items: center;
+            gap: 5px;
+        }
+        .example {
+            background: #f8f9fa;
+            padding: 8px 10px;
+            border-radius: 4px;
+            font-size: 0.85em;
+            margin-top: 5px;
+            border-left: 3px solid var(--secondary);
+        }
+        .partition-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+        }
+        .btn {
+            background: var(--secondary);
+            color: white;
+            border: none;
+            padding: 12px 20px;
+            font-size: 16px;
+            border-radius: 4px;
+            cursor: pointer;
+            width: 100%;
+            transition: all 0.3s;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+        }
+        .btn:hover {
+            background: #2980b9;
+            transform: translateY(-1px);
+        }
+        .btn-success {
+            background: var(--success);
+        }
+        .btn-success:hover {
+            background: #219653;
+        }
+        .btn-warning {
+            background: var(--warning);
+        }
+        .btn-warning:hover {
+            background: #d35400;
+        }
+        .btn-large {
+            padding: 14px 25px;
+            font-size: 18px;
+        }
+        footer {
+            text-align: center;
+            margin-top: 40px;
+            color: #777;
+            font-size: 0.9em;
+            padding-top: 20px;
+            border-top: 1px solid #eee;
+        }
+        .disk-visualization {
+            background: #f8f9fa;
+            border-radius: 6px;
+            padding: 15px;
+            margin-top: 15px;
+        }
+        .disk-summary {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 10px;
+            font-size: 0.9em;
+        }
+        .disk-chart {
+            height: 24px;
+            background: var(--light);
+            border-radius: 4px;
+            overflow: hidden;
+            margin-bottom: 10px;
+        }
+        .chart-bar {
+            display: flex;
+            height: 100%;
+            width: 100%;
+        }
+        .chart-segment {
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 0.7em;
+            transition: width 0.3s;
+        }
+        .chart-segment.efi { background: #9b59b6; }
+        .chart-segment.boot { background: #3498db; }
+        .chart-segment.root { background: #2ecc71; }
+        .chart-segment.home { background: #1abc9c; }
+        .chart-segment.var { background: #f39c12; }
+        .chart-segment.swap { background: #e74c3c; }
+        .disk-warning {
+            background: #fff8e6;
+            color: #d35400;
+            padding: 8px 10px;
+            border-radius: 4px;
+            font-size: 0.9em;
+            display: none;
+        }
+        .toggle-section {
+            background: #f8f9fa;
+            border-radius: 4px;
+            padding: 10px;
+            margin: 15px 0;
+        }
+        .toggle-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            cursor: pointer;
+        }
+        .toggle-icon {
+            transition: transform 0.3s;
+        }
+        .toggle-content {
+            padding-top: 10px;
+            display: none;
+        }
+        .toggle-content.active {
+            display: block;
+        }
+        .preset-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 15px;
+            margin-top: 15px;
+        }
+        .preset-card {
+            border: 2px solid #ddd;
+            border-radius: 8px;
+            padding: 15px;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+        .preset-card:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+        }
+        .preset-card.active {
+            border-color: var(--secondary);
+            background: #e9f7fe;
+        }
+        .preset-icon {
+            font-size: 2em;
+            margin-bottom: 10px;
+        }
+        .preset-example {
+            background: #f1f1f1;
+            border-radius: 4px;
+            padding: 10px;
+            margin-top: 10px;
+            font-size: 0.9em;
+        }
+        .example-row {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 3px;
+        }
+        .example-row span:first-child {
+            font-weight: bold;
+            color: var(--dark);
+        }
+        .mirror-row {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 10px;
+            align-items: center;
+        }
+        .mirror-row input {
+            flex: 1;
+        }
+        .wizard-navigation {
+            display: flex;
+            gap: 10px;
+            margin-top: 20px;
+        }
+        .preview-area {
+            background: #2c3e50;
+            color: #ecf0f1;
+            padding: 15px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 14px;
+            max-height: 400px;
+            overflow: auto;
+            white-space: pre-wrap;
+            margin-top: 15px;
+            display: none;
+        }
+        .history-section {
+            margin-top: 25px;
+        }
+        .history-item {
+            background: #f8f9fa;
+            padding: 12px;
+            border-radius: 4px;
+            margin-bottom: 10px;
+            cursor: pointer;
+            transition: all 0.2s;
+            border-left: 3px solid var(--secondary);
+        }
+        .history-item:hover {
+            background: #e9f7fe;
+            transform: translateX(5px);
+        }
+        .history-item strong {
+            color: var(--primary);
+        }
+        .password-strength {
+            height: 5px;
+            border-radius: 3px;
+            margin-top: 5px;
+            transition: width 0.3s;
+        }
+        .very-weak { background: var(--danger); width: 20%; }
+        .weak { background: #f39c12; width: 40%; }
+        .good { background: #f39c12; width: 70%; }
+        .strong { background: var(--success); width: 100%; }
+        .custom-name {
+            display: flex;
+            gap: 10px;
+            margin-top: 10px;
+        }
+        .custom-name input {
+            flex: 1;
+            padding: 5px;
+            font-size: 0.9em;
+        }
+        .hot-spare-container {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            background: #f8f9fa;
+            padding: 10px;
+            border-radius: 4px;
+            margin-top: 5px;
+        }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 50px;
+            height: 24px;
+        }
+        .toggle-switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: #ccc;
+            transition: .4s;
+            border-radius: 24px;
+        }
+        .slider:before {
+            position: absolute;
+            content: "";
+            height: 16px;
+            width: 16px;
+            left: 4px;
+            bottom: 4px;
+            background-color: white;
+            transition: .4s;
+            border-radius: 50%;
+        }
+        input:checked + .slider {
+            background-color: var(--success);
+        }
+        input:checked + .slider:before {
+            transform: translateX(26px);
+        }
+        @media (max-width: 768px) {
+            .form-grid {
+                grid-template-columns: 1fr;
+            }
+            .wizard-steps {
+                flex-direction: column;
+                gap: 5px;
+            }
+            .step {
+                padding: 8px 0;
+            }
+            .step-line {
+                display: none;
+            }
+            .partition-grid {
+                grid-template-columns: 1fr;
+            }
+            .preset-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Debian 12 Preseed Конструктор</h1>
+        </header>
+        <div class="setup-wizard">
+            <div class="wizard-steps">
+                <div class="step active" data-step="1">
+                    <span class="step-number">1</span>
+                    <span class="step-label">Базовые настройки</span>
+                    <span class="step-line"></span>
+                </div>
+                <div class="step" data-step="2">
+                    <span class="step-number">2</span>
+                    <span class="step-label">Диски и разделы</span>
+                    <span class="step-line"></span>
+                </div>
+                <div class="step" data-step="3">
+                    <span class="step-number">3</span>
+                    <span class="step-label">Сеть и пользователи</span>
+                    <span class="step-line"></span>
+                </div>
+                <div class="step" data-step="4">
+                    <span class="step-number">4</span>
+                    <span class="step-label">Интеграции</span>
+                </div>
+            </div>
+            <form id="preseed-form" action="{{ url_for('preseed.generate') }}" method="POST">
+                <!-- Шаг 1: Базовые настройки -->
+                <div class="config-card active" data-step="1">
+                    <div class="card-header">
+                        <h2>1. Базовые настройки</h2>
+                    </div>
+                    <div class="card-content">
+                        <div class="preset-grid">
+                            <div class="preset-card server active" data-preset="server">
+                                <div class="preset-icon">🏢</div>
+                                <h3><span class="preset-name-label">Сервер</span></h3>
+                                <p>RAID-1, 2 диска, стандартные разделы</p>
+                                <div class="custom-name">
+                                    <input type="text" class="preset-name-input" placeholder="Новое имя" style="display: none;">
+                                    <button type="button" class="btn btn-warning rename-btn" style="width: auto; padding: 0 10px; font-size: 0.9em;">Переименовать</button>
+                                </div>
+                                <div class="preset-example">
+                                    <div class="example-row"><span>Диски:</span> <span id="server-disk-count">2</span> × <span id="server-disk-size">500GB</span></div>
+                                    <div class="example-row"><span>RAID:</span> 1 (<span id="server-raid-space">500GB</span>)</div>
+                                </div>
+                            </div>
+                            <div class="preset-card desktop" data-preset="desktop">
+                                <div class="preset-icon">💻</div>
+                                <h3><span class="preset-name-label">Рабочая станция</span></h3>
+                                <p>RAID-1, 2 диска, большой /home</p>
+                                <div class="custom-name">
+                                    <input type="text" class="preset-name-input" placeholder="Новое имя" style="display: none;">
+                                    <button type="button" class="btn btn-warning rename-btn" style="width: auto; padding: 0 10px; font-size: 0.9em;">Переименовать</button>
+                                </div>
+                                <div class="preset-example">
+                                    <div class="example-row"><span>Диски:</span> <span id="desktop-disk-count">2</span> × <span id="desktop-disk-size">1TB</span></div>
+                                    <div class="example-row"><span>RAID:</span> 1 (<span id="desktop-raid-space">1TB</span>)</div>
+                                </div>
+                            </div>
+                            <div class="preset-card custom" data-preset="custom">
+                                <div class="preset-icon">⚙️</div>
+                                <h3><span class="preset-name-label">Пользовательский</span></h3>
+                                <p>Настройте все параметры вручную</p>
+                                <div class="custom-name">
+                                    <input type="text" class="preset-name-input" placeholder="Новое имя" style="display: none;">
+                                    <button type="button" class="btn btn-warning rename-btn" style="width: auto; padding: 0 10px; font-size: 0.9em;">Переименовать</button>
+                                </div>
+                                <div class="preset-example">
+                                    <div class="example-row"><span>Диски:</span> <span id="custom-disk-count">2</span></div>
+                                    <div class="example-row"><span>RAID:</span> <span id="custom-raid-level">1</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <h2>Тип RAID и диски</h2>
+                            <div class="form-group">
+                                <label for="raid_level">Тип RAID</label>
+                                <select id="raid_level" name="raid_level">
+                                    <option value="1" selected>RAID-1 (зеркало)</option>
+                                    <option value="0">RAID-0 (стрипинг)</option>
+                                </select>
+                                <div class="hint">ℹ️ Для RAID-1 требуется минимум 2 диска</div>
+                            </div>
+                            <div class="form-group">
+                                <label>Количество дисков</label>
+                                <div style="display: flex; align-items: center; gap: 10px; margin-top: 5px;">
+                                    <input type="number" id="disk_count" name="disk_count" min="1" value="2" required style="width: 100%;">
+                                    <div class="hot-spare-container">
+                                        <span>Hot spare</span>
+                                        <label class="toggle-switch">
+                                            <input type="checkbox" id="hot_spare" name="hot_spare">
+                                            <span class="slider"></span>
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="hint">ℹ️ Минимум 2 диска для RAID-1</div>
+                            </div>
+                            <div class="form-group">
+                                <label for="disk_size">Объем одного диска (GB)</label>
+                                <input type="number" id="disk_size" name="disk_size" min="10" value="500" required>
+                                <div class="hint">ℹ️ Например: 500 (для 500GB дисков)</div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <h2>Основные параметры</h2>
+                            <div class="form-group">
+                                <label for="hostname">Имя хоста</label>
+                                <input type="text" id="hostname" name="hostname" value="ks-debian-12" required>
+                                <div class="example">Пример: server-prod-01</div>
+                            </div>
+                            <div class="form-group">
+                                <label for="locale">Локаль</label>
+                                <select id="locale" name="locale">
+                                    <option value="en_US.UTF-8">Английский (en_US.UTF-8)</option>
+                                    <option value="ru_RU.UTF-8" selected>Русский (ru_RU.UTF-8)</option>
+                                    <option value="de_DE.UTF-8">Немецкий (de_DE.UTF-8)</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="timezone">Часовой пояс</label>
+                                <select id="timezone" name="timezone">
+                                    <option value="Europe/Moscow" selected>Москва (Europe/Moscow)</option>
+                                    <option value="Europe/London">Лондон (Europe/London)</option>
+                                    <option value="America/New_York">Нью-Йорк (America/New_York)</option>
+                                    <option value="Asia/Tokyo">Токио (Asia/Tokyo)</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- Шаг 2: Диски и разделы -->
+                <div class="config-card" data-step="2">
+                    <div class="card-header">
+                        <h2>2. Диски и разделы</h2>
+                    </div>
+                    <div class="card-content">
+                        <div class="section">
+                            <h2>Конфигурация разделов</h2>
+                            <div class="disk-visualization">
+                                <div class="disk-summary">
+                                    <div>Всего: <strong id="total-space">1000 GB</strong></div>
+                                    <div>Использовано: <strong id="used-space">488 GB</strong> (<span id="percent-used">48.8%</span>)</div>
+                                </div>
+                                <div class="disk-chart">
+                                    <div class="chart-bar">
+                                        <div class="chart-segment efi" style="width: 5%">EFI</div>
+                                        <div class="chart-segment boot" style="width: 10%">/boot</div>
+                                        <div class="chart-segment root" style="width: 40%">/</div>
+                                        <div class="chart-segment home" style="width: 25%">/home</div>
+                                        <div class="chart-segment var" style="width: 15%">/var</div>
+                                        <div class="chart-segment swap" style="width: 5%">Swap</div>
+                                    </div>
+                                </div>
+                                <div class="disk-warning" id="disk-warning">
+                                    ⚠️ Внимание: осталось менее 10% свободного места!
+                                </div>
+                            </div>
+                            <div class="partition-grid">
+                                <div class="form-group">
+                                    <label for="efi_size">EFI (MB)</label>
+                                    <input type="text" id="efi_size" name="efi_size" value="512" required>
+                                    <div class="example">Мин. 100MB, FAT32</div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="boot_size">/boot (MB)</label>
+                                    <input type="text" id="boot_size" name="boot_size" value="2048" required>
+                                </div>
+                                <div class="form-group">
+                                    <label for="root_size">/ (GB)</label>
+                                    <input type="text" id="root_size" name="root_size" value="100" required>
+                                    <div class="example">Основная система</div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="home_size">/home (GB)</label>
+                                    <input type="text" id="home_size" name="home_size" value="50" required>
+                                </div>
+                                <div class="form-group">
+                                    <label for="var_size">/var (GB)</label>
+                                    <input type="text" id="var_size" name="var_size" value="30" required>
+                                </div>
+                                <div class="form-group">
+                                    <label for="swap_size">Swap (GB)</label>
+                                    <input type="text" id="swap_size" name="swap_size" value="8" required>
+                                    <div class="example">Рекомендуется 1-2x RAM</div>
+                                </div>
+                            </div>
+                            <button type="button" id="auto-calc" class="btn btn-warning" style="margin-top: 15px;">
+                                🤖 Автоматический расчет
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                <!-- Шаг 3: Сеть и пользователи -->
+                <div class="config-card" data-step="3">
+                    <div class="card-header">
+                        <h2>3. Сеть и пользователи</h2>
+                    </div>
+                    <div class="card-content">
+                        <div class="section">
+                            <h2>Сетевые настройки</h2>
+                            <div class="form-group">
+                                <label>Тип сети</label>
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 5px;">
+                                    <label style="display: flex; align-items: center; gap: 5px;">
+                                        <input type="radio" name="net_mode" value="dhcp" checked>
+                                        DHCP
+                                    </label>
+                                    <label style="display: flex; align-items: center; gap: 5px;">
+                                        <input type="radio" name="net_mode" value="static">
+                                        Статический IP
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="toggle-section" id="static-fields" style="display: none;">
+                                <div class="toggle-header">
+                                    <span>Статические настройки сети</span>
+                                    <span class="toggle-icon">▶</span>
+                                </div>
+                                <div class="toggle-content active">
+                                    <div class="form-group">
+                                        <label for="net_ip">IP-адрес</label>
+                                        <input type="text" id="net_ip" name="net_ip" placeholder="192.168.1.100">
+                                        <div class="example">Пример: 192.168.1.100</div>
+                                    </div>
+                                    <div class="form-group">
+                                    <label for="net_netmask">Маска подсети</label>
+                                    <input type="text" id="net_netmask" name="net_netmask" placeholder="255.255.255.0">
+                                    <div class="example">Пример: 255.255.255.0</div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="net_gateway">Шлюз</label>
+                                    <input type="text" id="net_gateway" name="net_gateway" placeholder="192.168.1.1">
+                                    <div class="example">Пример: 192.168.1.1</div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="net_dns">DNS-серверы</label>
+                                    <input type="text" id="net_dns" name="net_dns" placeholder="8.8.8.8, 8.8.4.4">
+                                    <div class="example">Через запятую: 8.8.8.8, 1.1.1.1</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <h2>Учетные записи</h2>
+                            <div class="form-group">
+                                <label for="root_password">Пароль root</label>
+                                <input type="password" id="root_password" name="root_password" value="Q1w2a3s40007" required>
+                                <div class="password-strength" id="password-strength"></div>
+                                <div class="example">Минимум 8 символов</div>
+                            </div>
+                            <div class="form-group">
+                                <label for="username">Имя пользователя</label>
+                                <input type="text" id="username" name="username" value="sphera" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="user_password">Пароль пользователя</label>
+                                <input type="password" id="user_password" name="user_password" value="SpheraGuest!" required>
+                                <div class="example">Рекомендуется сложный пароль</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- Шаг 4: Интеграции -->
+                <div class="config-card" data-step="4">
+                    <div class="card-header">
+                        <h2>4. Интеграции</h2>
+                    </div>
+                    <div class="card-content">
+                        <div class="section">
+                            <h2>Зеркала APT</h2>
+                            <div class="form-group">
+                                <label>Режим зеркал</label>
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 5px;">
+                                    <label style="display: flex; align-items: center; gap: 5px;">
+                                        <input type="radio" name="mirror_mode" value="default" checked>
+                                        Стандартное зеркало
+                                    </label>
+                                    <label style="display: flex; align-items: center; gap: 5px;">
+                                        <input type="radio" name="mirror_mode" value="custom">
+                                        Кастомные зеркала
+                                    </label>
+                                </div>
+                            </div>
+                            <div id="default-mirror">
+                                <div class="form-group">
+                                    <label for="mirror_host">APT Зеркало (хост:порт)</label>
+                                    <input type="text" id="mirror_host" name="mirror_host" value="10.19.1.104:8081" required>
+                                    <div class="example">Пример: 192.168.1.100:8080</div>
+                                </div>
+                            </div>
+                            <div id="custom-mirrors" style="display: none;">
+                                <div class="form-group">
+                                    <label>Кастомные зеркала (формат: deb URL distro comp1 comp2)</label>
+                                    <div id="mirrors-container">
+                                        <div class="mirror-row">
+                                            <input type="text" name="mirror_url_1" placeholder="deb http://archive.debian.org/debian bookworm main">
+                                            <button type="button" class="btn btn-warning" style="width: auto; padding: 0 10px;">-</button>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="btn btn-warning" style="margin-top: 10px; width: auto; padding: 0 15px;">
+                                        + Добавить зеркало
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <h2>Регистрация IPXE</h2>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="enable_ipxe" name="enable_ipxe" checked>
+                                    Включить регистрацию на сервере
+                                </label>
+                                <div class="hint">Отправка данных на этапах DHCP и после установки</div>
+                            </div>
+                            <div id="ipxe-fields">
+                                <div class="form-group">
+                                    <label for="ipxe_url">URL сервера регистрации</label>
+                                    <input type="text" id="ipxe_url" name="ipxe_url" value="http://10.19.1.90:5000/api/register" required>
+                                    <div class="example">Пример: http://ваш-сервер:5000/api/register</div>
+                                </div>
+                                <div class="form-group">
+                                    <label>Этапы регистрации</label>
+                                    <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-top: 5px;">
+                                        <label style="display: flex; align-items: center; gap: 5px;">
+                                            <input type="checkbox" name="register_dhcp" checked>
+                                            После DHCP
+                                        </label>
+                                        <label style="display: flex; align-items: center; gap: 5px;">
+                                            <input type="checkbox" name="register_disk" checked>
+                                            После разметки дисков
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label>
+                                        <input type="checkbox" id="extended_registration" name="extended_registration" checked>
+                                        Расширенная регистрация с деталями
+                                    </label>
+                                    <div class="hint">Сохранение информации о дисках и отправка в base64</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <h2>Дополнительные настройки</h2>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="install_base_packages" name="install_base_packages" checked>
+                                    Установить базовые пакеты
+                                </label>
+                                <div class="hint">wget, curl, python3, шрифты и т.д.</div>
+                            </div>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="enable_root_ssh" name="enable_root_ssh" checked>
+                                    Разрешить root-доступ по SSH
+                                </label>
+                                <div class="hint">Добавляет PermitRootLogin yes в sshd_config</div>
+                            </div>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="disable_sound" name="disable_sound" checked>
+                                    Отключить звуковую систему
+                                </label>
+                                <div class="hint">Через blacklist snd_hda_intel</div>
+                            </div>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="fix_hostname" name="fix_hostname" checked>
+                                    Жестко задать имя хоста
+                                </label>
+                                <div class="hint">Имя хоста будет установлено как указано, без зависимости от DHCP</div>
+                            </div>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="show_ip" name="show_ip" checked>
+                                    Отображать IP в терминале
+                                </label>
+                                <div class="hint">IP будет отображаться при каждом входе в систему</div>
+                            </div>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="disable_video" name="disable_video">
+                                    Отключить видеодрайвер
+                                </label>
+                                <div class="hint">Решает проблемы с отображением на некоторых видеокартах</div>
+                            </div>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="enable_font" name="enable_font" checked>
+                                    Настроить шрифт TTY
+                                </label>
+                                <div class="hint">Выберите шрифт и размер для терминала</div>
+                            </div>
+                            <div id="font-settings" style="padding-left: 20px; margin-top: 10px;">
+                                <div class="form-group">
+                                    <label for="font_face">Тип шрифта</label>
+                                    <select id="font_face" name="font_face">
+                                        <option value="Terminus">Terminus</option>
+                                        <option value="Lat15">Lat15</option>
+                                        <option value="VGA">VGA</option>
+                                        <option value="Uni3-Terminus32x16">Uni3-Terminus32x16</option>
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label for="font_size">Размер шрифта</label>
+                                    <select id="font_size" name="font_size">
+                                        <option value="8x16">8x16</option>
+                                        <option value="8x8">8x8</option>
+                                        <option value="16x32" selected>16x32</option>
+                                        <option value="6x11">6x11</option>
+                                        <option value="6x10">6x10</option>
+                                        <option value="5x8">5x8</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <h2>Ansible интеграция</h2>
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" id="enable_ansible" name="enable_ansible" checked>
+                                    Включить автоматическую регистрацию в Ansible
+                                </label>
+                                <div class="hint">Скрипт запустится при первом старте системы</div>
+                            </div>
+                            <div id="ansible-fields">
+                                <div class="form-group">
+                                    <label for="ansible_script">URL скрипта регистрации</label>
+                                    <input type="text" id="ansible_script" name="ansible_script"
+                                           value="http://10.19.1.104:8081/repository/artifacts-local/other/config/ansible-register.sh" required>
+                                    <div class="example">Пример: http://repo.example.com/ansible-register.sh</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <h2>Предпросмотр и сохранение</h2>
+                            <button type="button" id="preview-btn" class="btn" style="background: #9b59b6; margin-bottom: 15px;">
+                                🔍 Предпросмотр preseed
+                            </button>
+                            <div id="preview-area" class="preview-area"></div>
+                            <div class="form-group" style="margin-top: 20px;">
+                                <label for="template-name">Сохранить как шаблон</label>
+                                <div style="display: flex; gap: 10px;">
+                                    <input type="text" id="template-name" placeholder="Имя шаблона" style="flex: 1;">
+                                    <button type="button" id="save-template" class="btn" style="background: var(--success); width: auto; padding: 0 15px;">Сохранить</button>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label for="load-template">Загрузить шаблон</label>
+                                <select id="load-template" style="width: 100%; padding: 8px; margin-bottom: 10px;">
+                                    <option value="">-- Выберите шаблон --</option>
+                                </select>
+                                <button type="button" id="apply-template" class="btn" style="background: var(--secondary); width: 100%;">Применить шаблон</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="wizard-steps bottom">
+                    <div class="step active" data-step="1">
+                        <span class="step-number">1</span>
+                        <span class="step-label">Базовые настройки</span>
+                        <span class="step-line"></span>
+                    </div>
+                    <div class="step" data-step="2">
+                        <span class="step-number">2</span>
+                        <span class="step-label">Диски и разделы</span>
+                        <span class="step-line"></span>
+                    </div>
+                    <div class="step" data-step="3">
+                        <span class="step-number">3</span>
+                        <span class="step-label">Сеть и пользователи</span>
+                        <span class="step-line"></span>
+                    </div>
+                    <div class="step" data-step="4">
+                        <span class="step-number">4</span>
+                        <span class="step-label">Интеграции</span>
+                    </div>
+                </div>
+                <div class="wizard-navigation">
+                    <button type="button" id="prev-step" class="btn" style="background: var(--dark);" disabled>Назад</button>
+                    <button type="button" id="next-step" class="btn">Далее</button>
+                    <button type="submit" id="generate-btn" class="btn btn-success btn-large" style="display: none;">
+                        📥 Скачать preseed.cfg
+                    </button>
+                </div>
+            </form>
+            <div class="history-section">
+                <h2>Последние генерации</h2>
+                <div id="history-list"></div>
+            </div>
+            <footer>
+                <p>Конструктор preseed-файлов для автоматической установки Debian 12 (bookworm)</p>
+                <p>Поддерживает RAID-0/1, UEFI, кастомные зеркала и интеграцию с Ansible</p>
+            </footer>
+        </div>
+    </div>
+    <script>
+        const BASE_URL = "{{ url_for('preseed.index') }}";
+        let currentStep = 1;
+        const totalSteps = 4;
+        let presetNames = {
+            server: "Сервер",
+            desktop: "Рабочая станция",
+            custom: "Пользовательский"
+        };
+        document.addEventListener('DOMContentLoaded', function() {
+            initInterface();
+            loadTemplates();
+            loadHistory();
+        });
+        function initInterface() {
+            initPresetNames();
+            setupWizardNavigation();
+            setupModeSwitches();
+            setupDiskVisualization();
+            setupPresetCards();
+            setupValidation();
+            setupTemplateHandlers();
+            setupHistoryHandlers();
+        }
+        function initPresetNames() {
+            document.querySelectorAll('.preset-card').forEach(card => {
+                const preset = card.dataset.preset;
+                const name = presetNames[preset] || preset.charAt(0).toUpperCase() + preset.slice(1);
+                card.querySelector('.preset-name-label').textContent = name;
+            });
+        }
+        function setupWizardNavigation() {
+            document.getElementById('next-step').addEventListener('click', function() {
+                if (currentStep < totalSteps) {
+                    goToStep(currentStep + 1);
+                }
+            });
+            document.getElementById('prev-step').addEventListener('click', function() {
+                if (currentStep > 1) {
+                    goToStep(currentStep - 1);
+                }
+            });
+            document.querySelectorAll('.wizard-steps .step').forEach(stepEl => {
+                stepEl.addEventListener('click', () => {
+                    const stepNum = parseInt(stepEl.dataset.step);
+                    goToStep(stepNum);
+                });
+            });
+            document.addEventListener('keydown', e => {
+                if (e.key >= '1' && e.key <= String(totalSteps)) {
+                    goToStep(parseInt(e.key));
+                }
+            });
+            window.goToStep = function(step) {
+                if (step < 1 || step > totalSteps) return;
+                document.querySelectorAll('.config-card').forEach(card => {
+                    card.style.display = 'none';
+                    card.classList.remove('active');
+                });
+                document.querySelectorAll('.wizard-steps .step').forEach(stepEl => {
+                    stepEl.classList.remove('active', 'completed');
+                });
+                const currentCard = document.querySelector(`.config-card[data-step="${step}"]`);
+                currentCard.style.display = 'block';
+                currentCard.classList.add('active');
+                const steps = document.querySelectorAll('.wizard-steps .step');
+                steps.forEach(s => {
+                    const stepNum = parseInt(s.dataset.step);
+                    if (stepNum < step) s.classList.add('completed');
+                    else if (stepNum === step) s.classList.add('active');
+                });
+                document.getElementById('prev-step').disabled = (step === 1);
+                document.getElementById('next-step').style.display = (step === totalSteps) ? 'none' : 'block';
+                document.getElementById('generate-btn').style.display = (step === totalSteps) ? 'block' : 'none';
+                currentStep = step;
+                window.scrollTo(0,0);
+            }
+            goToStep(1);
+        }
+        function setupModeSwitches() {
+            document.querySelectorAll('input[name="net_mode"]').forEach(radio => {
+                radio.addEventListener('change', function() {
+                    const staticFields = document.getElementById('static-fields');
+                    staticFields.style.display = this.value === 'static' ? 'block' : 'none';
+                });
+            });
+            document.querySelectorAll('input[name="mirror_mode"]').forEach(radio => {
+                radio.addEventListener('change', function() {
+                    document.getElementById('default-mirror').style.display = this.value === 'default' ? 'block' : 'none';
+                    document.getElementById('custom-mirrors').style.display = this.value === 'custom' ? 'block' : 'none';
+                });
+            });
+            document.getElementById('enable_ipxe').addEventListener('change', function() {
+                document.getElementById('ipxe-fields').style.display = this.checked ? 'block' : 'none';
+            });
+            document.getElementById('enable_ansible').addEventListener('change', function() {
+                document.getElementById('ansible-fields').style.display = this.checked ? 'block' : 'none';
+            });
+            document.getElementById('enable_font').addEventListener('change', function() {
+                document.getElementById('font-settings').style.display = this.checked ? 'block' : 'none';
+            });
+            document.querySelectorAll('.toggle-header').forEach(header => {
+                header.addEventListener('click', function() {
+                    const content = this.nextElementSibling;
+                    const icon = this.querySelector('.toggle-icon');
+                    if (content.classList.contains('active')) {
+                        content.classList.remove('active');
+                        icon.textContent = '▶';
+                    } else {
+                        content.classList.add('active');
+                        icon.textContent = '▼';
+                    }
+                });
+            });
+            document.querySelectorAll('.rename-btn').forEach(btn => {
+                btn.addEventListener('click', function() {
+                    const card = this.closest('.preset-card');
+                    const input = card.querySelector('.preset-name-input');
+                    const label = card.querySelector('.preset-name-label');
+                    if (input.style.display === 'none') {
+                        input.style.display = 'block';
+                        input.value = label.textContent;
+                        input.focus();
+                        this.textContent = 'Сохранить';
+                    } else {
+                        const newName = input.value.trim();
+                        if (newName) {
+                            const preset = card.dataset.preset;
+                            presetNames[preset] = newName;
+                            label.textContent = newName;
+                        }
+                        input.style.display = 'none';
+                        this.textContent = 'Переименовать';
+                    }
+                });
+            });
+        }
+        function setupDiskVisualization() {
+            function updateVisualization() {
+                const diskSize = parseInt(document.getElementById('disk_size').value) || 500;
+                const diskCount = parseInt(document.getElementById('disk_count').value) || 1;
+                const raidLevel = document.getElementById('raid_level').value;
+                const hotSpare = document.getElementById('hot_spare').checked;
+                let totalSpace;
+                if (raidLevel === '0') totalSpace = diskSize * diskCount;
+                else if (raidLevel === '1') totalSpace = diskSize;
+                const used = [
+                    parseInt(document.getElementById('efi_size').value) || 0,
+                    parseInt(document.getElementById('boot_size').value) || 0,
+                    parseInt(document.getElementById('root_size').value) || 0,
+                    parseInt(document.getElementById('home_size').value) || 0,
+                    parseInt(document.getElementById('var_size').value) || 0,
+                    parseInt(document.getElementById('swap_size').value) || 0
+                ].reduce((a, b) => a + b, 0);
+                const remaining = totalSpace - used;
+                const percent = Math.min(100, Math.round((used / totalSpace) * 100));
+                document.getElementById('total-space').textContent = `${totalSpace} GB`;
+                document.getElementById('used-space').textContent = `${used} GB`;
+                document.getElementById('percent-used').textContent = `${percent}%`;
+                const segments = [
+                    {id: 'efi', size: parseInt(document.getElementById('efi_size').value) || 0},
+                    {id: 'boot', size: parseInt(document.getElementById('boot_size').value) || 0},
+                    {id: 'root', size: parseInt(document.getElementById('root_size').value) || 0},
+                    {id: 'home', size: parseInt(document.getElementById('home_size').value) || 0},
+                    {id: 'var', size: parseInt(document.getElementById('var_size').value) || 0},
+                    {id: 'swap', size: parseInt(document.getElementById('swap_size').value) || 0}
+                ];
+                let totalUsed = segments.reduce((sum, seg) => sum + seg.size, 0);
+                segments.forEach(seg => {
+                    const width = totalUsed > 0 ? (seg.size / totalUsed) * 100 : 0;
+                    const el = document.querySelector(`.chart-segment.${seg.id}`);
+                    el.style.width = `${width}%`;
+                });
+                document.getElementById('disk-warning').style.display =
+                    remaining < (totalSpace * 0.1) ? 'block' : 'none';
+                updatePresetPreviews();
+            }
+            const inputs = [
+                'disk_size', 'disk_count', 'raid_level', 'hot_spare',
+                'efi_size', 'boot_size', 'root_size',
+                'home_size', 'var_size', 'swap_size'
+            ];
+            inputs.forEach(id => {
+                const el = document.getElementById(id);
+                if (el) el.addEventListener('input', updateVisualization);
+            });
+            document.getElementById('auto-calc').addEventListener('click', function() {
+                const diskSize = parseInt(document.getElementById('disk_size').value) || 500;
+                const diskCount = parseInt(document.getElementById('disk_count').value) || 1;
+                const raidLevel = document.getElementById('raid_level').value;
+                const hotSpare = document.getElementById('hot_spare').checked;
+                let totalSpace;
+                if (raidLevel === '0') totalSpace = diskSize * diskCount;
+                else if (raidLevel === '1') totalSpace = diskSize;
+                const recommended = {
+                    root: Math.min(100, Math.floor(totalSpace * 0.4)),
+                    home: Math.min(50, Math.floor(totalSpace * 0.3)),
+                    var: Math.min(30, Math.floor(totalSpace * 0.2)),
+                    swap: Math.min(16, Math.max(4, Math.floor((diskSize * 0.02))))
+                };
+                document.getElementById('root_size').value = recommended.root;
+                document.getElementById('home_size').value = recommended.home;
+                document.getElementById('var_size').value = recommended.var;
+                document.getElementById('swap_size').value = recommended.swap;
+                updateVisualization();
+            });
+            updateVisualization();
+        }
+        function updatePresetPreviews() {
+            const diskSize = parseInt(document.getElementById('disk_size').value) || 500;
+            const diskCount = parseInt(document.getElementById('disk_count').value) || 1;
+            const raidLevel = document.getElementById('raid_level').value;
+            const hotSpare = document.getElementById('hot_spare').checked;
+            let totalSpace;
+            if (raidLevel === '0') totalSpace = diskSize * diskCount;
+            else if (raidLevel === '1') totalSpace = diskSize;
+            document.getElementById('custom-disk-count').textContent = diskCount;
+            document.getElementById('custom-raid-level').textContent = raidLevel + (hotSpare ? ' + hot spare' : '');
+            document.getElementById('server-disk-count').textContent = diskCount;
+            document.getElementById('server-disk-size').textContent = `${diskSize}GB`;
+            document.getElementById('server-raid-space').textContent = `${totalSpace}GB`;
+            document.getElementById('desktop-disk-count').textContent = diskCount;
+            document.getElementById('desktop-disk-size').textContent = `${diskSize}GB`;
+            document.getElementById('desktop-raid-space').textContent = `${totalSpace}GB`;
+        }
+        function setupPresetCards() {
+            document.querySelectorAll('.preset-card').forEach(card => {
+                card.addEventListener('click', function() {
+                    document.querySelectorAll('.preset-card').forEach(c => {
+                        c.classList.remove('active');
+                    });
+                    this.classList.add('active');
+                    const preset = this.dataset.preset;
+                    if (preset === 'server') {
+                        document.getElementById('raid_level').value = '1';
+                        document.getElementById('hot_spare').checked = false;
+                        document.getElementById('disk_count').value = '2';
+                        document.getElementById('disk_size').value = '500';
+                        document.getElementById('efi_size').value = '512';
+                        document.getElementById('boot_size').value = '2048';
+                        document.getElementById('root_size').value = '100';
+                        document.getElementById('home_size').value = '200';
+                        document.getElementById('var_size').value = '80';
+                        document.getElementById('swap_size').value = '16';
+                        document.getElementById('enable_ipxe').checked = true;
+                        document.getElementById('enable_ansible').checked = true;
+                        document.getElementById('install_base_packages').checked = true;
+                        document.getElementById('enable_root_ssh').checked = true;
+                        document.getElementById('disable_sound').checked = true;
+                        document.getElementById('extended_registration').checked = true;
+                    } else if (preset === 'desktop') {
+                        document.getElementById('raid_level').value = '1';
+                        document.getElementById('hot_spare').checked = false;
+                        document.getElementById('disk_count').value = '2';
+                        document.getElementById('disk_size').value = '1000';
+                        document.getElementById('efi_size').value = '512';
+                        document.getElementById('boot_size').value = '1024';
+                        document.getElementById('root_size').value = '200';
+                        document.getElementById('home_size').value = '600';
+                        document.getElementById('var_size').value = '50';
+                        document.getElementById('swap_size').value = '32';
+                        document.getElementById('enable_ipxe').checked = false;
+                        document.getElementById('install_base_packages').checked = true;
+                        document.getElementById('enable_root_ssh').checked = true;
+                        document.getElementById('disable_sound').checked = true;
+                    }
+                    setupModeSwitches();
+                    setupDiskVisualization();
+                    goToStep(1);
+                });
+            });
+        }
+        function setupValidation() {
+            document.getElementById('root_password').addEventListener('input', function() {
+                const strength = checkPasswordStrength(this.value);
+                const strengthBar = document.getElementById('password-strength');
+                strengthBar.className = 'password-strength ' + strength.level;
+                if (strength.score < 3) {
+                    this.setCustomValidity("Пароль слишком слабый");
+                } else {
+                    this.setCustomValidity("");
+                }
+            });
+            function checkPasswordStrength(password) {
+                let score = 0;
+                let level = "very-weak";
+                if (password.length >= 8) score++;
+                if (/[A-Z]/.test(password)) score++;
+                if (/[a-z]/.test(password)) score++;
+                if (/[0-9]/.test(password)) score++;
+                if (/[^A-Za-z0-9]/.test(password)) score++;
+                if (score === 2) level = "weak";
+                else if (score === 3) level = "good";
+                else if (score >= 4) level = "strong";
+                return {score, level};
+            }
+            document.getElementById('preview-btn').addEventListener('click', async function() {
+                const form = document.getElementById('preseed-form');
+                const previewArea = document.getElementById('preview-area');
+                previewArea.textContent = 'Генерация...';
+                previewArea.style.display = 'block';
+                try {
+                    const formData = new FormData(form);
+                    const response = await fetch(BASE_URL + 'preview', {
+                        method: 'POST',
+                        body: new URLSearchParams(formData)
+                    });
+                    if (!response.ok) {
+                        throw new Error(await response.text());
+                    }
+                    const preview = await response.text();
+                    previewArea.textContent = preview;
+                } catch (error) {
+                    previewArea.innerHTML = `<span style="color: var(--danger);">Ошибка: ${error.message}</span>`;
+                }
+            });
+        }
+        function setupTemplateHandlers() {
+            async function loadTemplates() {
+                try {
+                    const response = await fetch(BASE_URL + 'api/templates');
+                    const templates = await response.json();
+                    const select = document.getElementById('load-template');
+                    select.innerHTML = '<option value="">-- Выберите шаблон --</option>';
+                    templates.forEach(template => {
+                        const option = document.createElement('option');
+                        option.value = template.name;
+                        option.textContent = template.name;
+                        select.appendChild(option);
+                    });
+                } catch (e) {
+                    console.error("Ошибка загрузки шаблонов:", e);
+                }
+            }
+            document.getElementById('save-template').addEventListener('click', async function() {
+                const name = document.getElementById('template-name').value.trim();
+                if (!name) {
+                    alert("Введите имя шаблона");
+                    return;
+                }
+                const form = document.getElementById('preseed-form');
+                const formData = new FormData(form);
+                const data = {};
+                for (const [key, value] of formData) {
+                    data[key] = value;
+                }
+                data.presetNames = JSON.stringify(presetNames);
+                try {
+                    const response = await fetch(BASE_URL + 'api/save-template', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ name, data })
+                    });
+                    if (response.ok) {
+                        alert("Шаблон сохранен!");
+                        document.getElementById('template-name').value = '';
+                        loadTemplates();
+                    } else {
+                        alert("Ошибка сохранения: " + await response.text());
+                    }
+                } catch (e) {
+                    alert("Ошибка сети: " + e.message);
+                }
+            });
+            document.getElementById('apply-template').addEventListener('click', async function() {
+                const templateName = document.getElementById('load-template').value;
+                if (!templateName) return;
+                try {
+                    const response = await fetch(BASE_URL + 'api/template/' + encodeURIComponent(templateName));
+                    const data = await response.json();
+                    Object.keys(data).forEach(key => {
+                        if (key === 'presetNames') {
+                            try {
+                                presetNames = JSON.parse(data[key]);
+                                initPresetNames();
+                            } catch (e) {
+                                console.error("Ошибка парсинга presetNames:", e);
+                            }
+                            return;
+                        }
+                        const el = document.querySelector(`[name="${key}"]`);
+                        if (el) {
+                            if (el.type === 'checkbox' || el.type === 'radio') {
+                                el.checked = (data[key] === 'on' || data[key] === true || data[key] === 'true');
+                            } else {
+                                el.value = data[key];
+                            }
+                        }
+                    });
+                    setupModeSwitches();
+                    setupDiskVisualization();
+                    alert("Шаблон применен!");
+                } catch (e) {
+                    alert("Ошибка загрузки шаблона: " + e.message);
+                }
+            });
+            loadTemplates();
+        }
+        function setupHistoryHandlers() {
+            async function loadHistory() {
+                try {
+                    const response = await fetch(BASE_URL + 'api/history');
+                    const history = await response.json();
+                    const historyList = document.getElementById('history-list');
+                    historyList.innerHTML = '';
+                    if (history.length === 0) {
+                        historyList.innerHTML = '<div class="history-item">История пуста</div>';
+                        return;
+                    }
+                    history.slice(-5).reverse().forEach(item => {
+                        const div = document.createElement('div');
+                        div.className = 'history-item';
+                        div.innerHTML = `
+                            <strong>${new Date(item.timestamp).toLocaleString()}</strong> |
+                            <span>Хост: ${item.params.hostname}</span>
+                            <div style="display: flex; gap: 10px; margin-top: 8px;">
+                                <button class="btn btn-warning" style="padding: 5px 10px; font-size: 0.9em;" onclick="loadHistoryItem('${item.timestamp}')">Загрузить</button>
+                                <button class="btn btn-success" style="padding: 5px 10px; font-size: 0.9em;" onclick="downloadHistoryItem('${item.timestamp}')">Скачать</button>
+                            </div>
+                        `;
+                        historyList.appendChild(div);
+                    });
+                } catch (e) {
+                    console.error("Ошибка загрузки истории:", e);
+                }
+            }
+            window.loadHistoryItem = async function(timestamp) {
+                try {
+                    const response = await fetch(BASE_URL + 'api/history');
+                    const history = await response.json();
+                    const item = history.find(h => h.timestamp === timestamp);
+                    if (!item) return;
+                    Object.keys(item.params).forEach(key => {
+                        if (key === 'presetNames') {
+                            try {
+                                presetNames = JSON.parse(item.params[key]);
+                                initPresetNames();
+                            } catch (e) {
+                                console.error("Ошибка парсинга presetNames:", e);
+                            }
+                            return;
+                        }
+                        const el = document.querySelector(`[name="${key}"]`);
+                        if (el) {
+                            if (el.type === 'checkbox' || el.type === 'radio') {
+                                el.checked = (item.params[key] === 'on' || item.params[key] === true || item.params[key] === 'true');
+                            } else {
+                                el.value = item.params[key];
+                            }
+                        }
+                    });
+                    setupModeSwitches();
+                    setupDiskVisualization();
+                    alert("Конфигурация из истории загружена!");
+                } catch (e) {
+                    alert("Ошибка загрузки из истории: " + e.message);
+                }
+            };
+            window.downloadHistoryItem = async function(timestamp) {
+                try {
+                    const response = await fetch(BASE_URL + 'api/history');
+                    const history = await response.json();
+                    const item = history.find(h => h.timestamp === timestamp);
+                    if (!item) return;
+                    const blob = new Blob([item.preseed_preview.replace('...', '')], {type: 'text/plain'});
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `debian12-preseed-${item.params.hostname}.cfg`;
+                    document.body.appendChild(a);
+                    a.click();
+                    setTimeout(() => {
+                        document.body.removeChild(a);
+                        URL.revokeObjectURL(url);
+                    }, 100);
+                } catch (e) {
+                    alert("Ошибка скачивания: " + e.message);
+                }
+            };
+            loadHistory();
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone preseed configurator blueprint with RAID-0/1 support and history
- include full HTML UI with step navigation and keyboard shortcuts
- link configurator from main dashboard

## Testing
- `python -m py_compile preseed.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_689efdec823483279b6021b07aee3fba