### PR TITLE
Fix preseed configurator routing and highlight dashboard button

### DIFF
--- a/logtail.py
+++ b/logtail.py
@@ -82,10 +82,18 @@ def init_logtail_db():
         )
 
 
-@logtail_bp.before_app_first_request
+# Flask 1.x doesn't provide `before_app_first_request` for blueprints.
+# Use a regular `before_app_request` hook and run the initialisation once.
+_db_initialised = False
+
+
+@logtail_bp.before_app_request
 def _init_db() -> None:
-    """Initialise DB once application starts."""
-    init_logtail_db()
+    """Initialise DB once per application startup."""
+    global _db_initialised
+    if not _db_initialised:
+        init_logtail_db()
+        _db_initialised = True
 
 
 def load_inventory():

--- a/preseed.py
+++ b/preseed.py
@@ -76,8 +76,8 @@ def api_save_template():
 def api_history():
     return jsonify(load_history())
 
-@preseed_bp.route('/preview', methods=['POST'])
-@preseed_bp.route('/generate', methods=['POST'])
+@preseed_bp.route('/preview', methods=['POST'], endpoint='preview')
+@preseed_bp.route('/generate', methods=['POST'], endpoint='generate')
 def preview_or_generate():
     try:
         raid_level = request.form.get('raid_level', '1')

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -116,6 +116,9 @@
     .btn-logtail { background: var(--logtail); padding: 6px 10px; font-size: 0.85em; }
     .btn-logtail:hover { background: #7b1fa2; }
     .btn-logtail i { font-size: 0.9em; }
+    .btn-preseed { background: var(--orange); padding: 6px 10px; font-size: 0.85em; }
+    .btn-preseed:hover { background: #fb8c00; }
+    .btn-preseed i { font-size: 0.9em; }
     .container { padding: 24px; }
     table {
       width: 100%;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -26,11 +26,13 @@
         <a class="btn btn-logtail" href="{{ url_for('logtail.logtail_dashboard') }}" target="_blank" rel="noopener noreferrer">
           <i class="fas fa-file-alt"></i> Logtail
         </a>
+        <a class="btn btn-preseed" href="{{ url_for('preseed.index') }}" target="_blank" rel="noopener noreferrer">
+          <i class="fa fa-wrench"></i> Preseed Configurator
+        </a>
       </div>
       <div class="divider"></div>
       <div class="header-group">
         <button class="btn" id="edit-preseed"><i class="fa fa-edit"></i> Preseed</button>
-        <a class="btn" href="{{ url_for('preseed.index') }}"><i class="fa fa-wrench"></i> Preseed Configurator</a>
         <button class="btn" id="edit-dnsmasq"><i class="fa fa-network-wired"></i> DHCP / iPXE</button>
         <button class="btn" id="edit-ipxe"><i class="fa fa-code"></i> iPXE</button>
       </div>


### PR DESCRIPTION
## Summary
- avoid startup crash by initializing Logtail DB in a `before_app_request` hook
- expose distinct `generate` endpoint for preseed to prevent 500 errors
- move Preseed Configurator button next to Logtail and highlight it in orange

## Testing
- `python3 -m py_compile app.py preseed.py logtail.py`
- `python3 app.py` and `curl -s -o /tmp/preseed.html -w "%{http_code}\n" http://localhost:5000/preseed/`

------
https://chatgpt.com/codex/tasks/task_e_689f0285a9e483279e782535ca84cb35