### PR TITLE
Add preseed builder interface

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -296,4 +296,7 @@
         }
       }
     });
+    document.getElementById('open-preseed-builder').onclick = () => {
+      window.open('/preseed-builder', '_blank');
+    };
     overlay.onclick = () => modals.forEach(closeModal);

--- a/static/js/preseed_builder.js
+++ b/static/js/preseed_builder.js
@@ -1,0 +1,39 @@
+// Preseed builder logic
+function generatePreseed() {
+  const hostname = document.getElementById('hostname').value || 'debian';
+  const domain = document.getElementById('domain').value || 'local';
+  const rootPass = document.getElementById('root-pass').value || 'root';
+  const timezone = document.getElementById('timezone').value || 'UTC';
+  const text = [
+    `d-i netcfg/get_hostname string ${hostname}`,
+    `d-i netcfg/get_domain string ${domain}`,
+    'd-i netcfg/choose_interface select auto',
+    'd-i netcfg/disable_dhcp boolean false',
+    `d-i time/zone string ${timezone}`,
+    'd-i clock-setup/utc boolean true',
+    `d-i passwd/root-password password ${rootPass}`,
+    `d-i passwd/root-password-again password ${rootPass}`,
+    'd-i pkgsel/include string openssh-server curl',
+    'd-i finish-install/reboot_in_progress note'
+  ].join('\n');
+  document.getElementById('preseed-text').value = text + '\n';
+}
+async function savePreseed() {
+  const content = document.getElementById('preseed-text').value;
+  try {
+    const res = await fetch('/api/preseed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: content
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.msg || res.statusText);
+    }
+    alert('Сохранено');
+  } catch (e) {
+    alert('Ошибка: ' + e.message);
+  }
+}
+document.getElementById('generate').onclick = generatePreseed;
+document.getElementById('save').onclick = savePreseed;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -30,6 +30,7 @@
       <div class="divider"></div>
       <div class="header-group">
         <button class="btn" id="edit-preseed"><i class="fa fa-edit"></i> Preseed</button>
+        <button class="btn" id="open-preseed-builder"><i class="fa fa-wrench"></i> Конструктор</button>
         <button class="btn" id="edit-dnsmasq"><i class="fa fa-network-wired"></i> DHCP / iPXE</button>
         <button class="btn" id="edit-ipxe"><i class="fa fa-code"></i> iPXE</button>
       </div>

--- a/templates/preseed_builder.html
+++ b/templates/preseed_builder.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <title>Preseed Builder</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+</head>
+<body>
+  <header>
+    <h1><i class="fa fa-wrench"></i> Preseed Builder</h1>
+  </header>
+  <div class="container">
+    <form id="preseed-form" class="form">
+      <div class="form-group">
+        <label>Hostname
+          <input type="text" id="hostname" placeholder="debian">
+        </label>
+      </div>
+      <div class="form-group">
+        <label>Domain
+          <input type="text" id="domain" placeholder="local">
+        </label>
+      </div>
+      <div class="form-group">
+        <label>Root password
+          <input type="password" id="root-pass" placeholder="root">
+        </label>
+      </div>
+      <div class="form-group">
+        <label>Timezone
+          <input type="text" id="timezone" value="UTC">
+        </label>
+      </div>
+      <div class="form-group" style="display:flex;gap:8px;">
+        <button type="button" class="btn" id="generate"><i class="fa fa-cogs"></i> Сгенерировать</button>
+        <button type="button" class="btn" id="save"><i class="fa fa-save"></i> Сохранить</button>
+      </div>
+    </form>
+    <textarea id="preseed-text" style="width:100%;height:300px;"></textarea>
+  </div>
+  <script src="{{ url_for('static', filename='js/preseed_builder.js') }}"></script>
+</body>
+</html>

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -68,3 +68,7 @@ def dashboard():
         stage_labels=STAGE_LABELS,
         ansible_files_path=ANSIBLE_FILES_DIR,
     )
+
+@web_bp.route('/preseed-builder')
+def preseed_builder():
+    return render_template('preseed_builder.html')


### PR DESCRIPTION
## Summary
- add web page to build preseed configs with form and JS generation
- hook builder to existing `/api/preseed` endpoint and expose route `/preseed-builder`
- add dashboard button linking to the builder

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a40b5012e88327b880d48b5ea4e702