### PR TITLE
Improve file browser and dashboard summary

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -115,8 +115,34 @@
     .btn-shutdown i { font-size: 0.9em; }
     .btn-logtail { background: var(--logtail); padding: 6px 10px; font-size: 0.85em; }
     .btn-logtail:hover { background: #7b1fa2; }
-    .btn-logtail i { font-size: 0.9em; }
-    .container { padding: 24px; }
+      .btn-logtail i { font-size: 0.9em; }
+      .stats-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        padding: 24px;
+      }
+      .stat-card {
+        flex: 1 1 180px;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 16px 24px;
+        box-shadow: var(--table-shadow);
+      }
+      .stat-number {
+        font-size: 1.6em;
+        font-weight: 600;
+      }
+      .stat-title {
+        font-weight: 600;
+        margin-top: 8px;
+      }
+      .stat-subtitle {
+        color: var(--grey);
+        font-size: 0.85em;
+      }
+      .container { padding: 24px; }
     table {
       width: 100%;
       border-collapse: collapse;

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -175,7 +175,9 @@
                 listBody.appendChild(upTr);
             }
             if (data.files.length === 0) {
-                listBody.innerHTML += '<tr><td colspan="3" style="text-align: center; font-style: italic;">Файлы не найдены</td></tr>';
+                const emptyTr = document.createElement('tr');
+                emptyTr.innerHTML = '<td colspan="3" style="text-align: center; font-style: italic;">Файлы не найдены</td>';
+                listBody.appendChild(emptyTr);
                 return;
             }
             data.files.forEach(file => {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -50,6 +50,28 @@
     <h4><i class="fa fa-terminal"></i> Журнал выполнения Ansible</h4>
     <div class="log-viewer" id="ansible-log"></div>
   </div>
+  <div class="stats-container">
+    <div class="stat-card">
+      <div class="stat-number">{{ total_hosts }}</div>
+      <div class="stat-title">Total Hosts</div>
+      <div class="stat-subtitle">Active monitoring</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-number">{{ online_hosts }}</div>
+      <div class="stat-title">Online</div>
+      <div class="stat-subtitle">Connected now</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-number">{{ installing_hosts }}</div>
+      <div class="stat-title">Installing</div>
+      <div class="stat-subtitle">In progress</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-number">{{ completed_hosts }}</div>
+      <div class="stat-title">Completed</div>
+      <div class="stat-subtitle">Successfully deployed</div>
+    </div>
+  </div>
   <div class="container">
     <table>
       <thead>


### PR DESCRIPTION
## Summary
- Ensure file browser allows navigating back from empty directories
- Show host statistics on the dashboard with new summary cards

## Testing
- `python -m py_compile web/__init__.py`
- `python -m py_compile api/ansible.py`
- `node --check static/js/dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4123c57288327a67f3d6afa5a1d25