### PR TITLE
feat: improve dashboard and fix file browser navigation

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -117,6 +117,39 @@
     .btn-logtail:hover { background: #7b1fa2; }
     .btn-logtail i { font-size: 0.9em; }
     .container { padding: 24px; }
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+    .stat-card {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px;
+      box-shadow: var(--table-shadow);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    .stat-number {
+      font-size: 2em;
+      font-weight: 600;
+    }
+    .stat-label {
+      margin-top: 4px;
+      font-size: 0.9em;
+      color: var(--grey);
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .stat-card.online .stat-number { color: var(--green); }
+    .stat-card.installing .stat-number { color: var(--orange); }
+    .stat-card.completed .stat-number { color: var(--accent); }
     table {
       width: 100%;
       border-collapse: collapse;

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -175,7 +175,9 @@
                 listBody.appendChild(upTr);
             }
             if (data.files.length === 0) {
-                listBody.innerHTML += '<tr><td colspan="3" style="text-align: center; font-style: italic;">Файлы не найдены</td></tr>';
+                const emptyTr = document.createElement('tr');
+                emptyTr.innerHTML = '<td colspan="3" style="text-align: center; font-style: italic;">Файлы не найдены</td>';
+                listBody.appendChild(emptyTr);
                 return;
             }
             data.files.forEach(file => {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -51,6 +51,24 @@
     <div class="log-viewer" id="ansible-log"></div>
   </div>
   <div class="container">
+    <div class="stats-grid">
+      <div class="stat-card total">
+        <div class="stat-number">{{ total_hosts }}</div>
+        <div class="stat-label"><i class="fa fa-list"></i> Total Hosts</div>
+      </div>
+      <div class="stat-card online">
+        <div class="stat-number">{{ online_hosts }}</div>
+        <div class="stat-label"><i class="fa fa-circle"></i> Online</div>
+      </div>
+      <div class="stat-card installing">
+        <div class="stat-number">{{ installing_hosts }}</div>
+        <div class="stat-label"><i class="fa fa-download"></i> Installing</div>
+      </div>
+      <div class="stat-card completed">
+        <div class="stat-number">{{ completed_hosts }}</div>
+        <div class="stat-label"><i class="fa fa-check"></i> Completed</div>
+      </div>
+    </div>
     <table>
       <thead>
         <tr>

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -62,9 +62,17 @@ def dashboard():
             'online': is_online,
             'details': details or '',
         })
+    total_hosts = len(hosts)
+    online_hosts = sum(1 for h in hosts if h['online'])
+    installing_hosts = sum(1 for row in rows if row[2] == 'debian_install')
+    completed_hosts = sum(1 for h in hosts if h['stage'].startswith('✅'))
     return render_template(
         'dashboard.html',
         hosts=hosts,
         stage_labels=STAGE_LABELS,
         ansible_files_path=ANSIBLE_FILES_DIR,
+        total_hosts=total_hosts,
+        online_hosts=online_hosts,
+        installing_hosts=installing_hosts,
+        completed_hosts=completed_hosts,
     )


### PR DESCRIPTION
## Summary
- show total/online/installing/completed host counts on dashboard
- keep back navigation in file manager when directory empty

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4123c57288327a67f3d6afa5a1d25