### PR TITLE
Improve dashboard stats and file browser navigation

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -117,6 +117,14 @@
     .btn-logtail:hover { background: #7b1fa2; }
     .btn-logtail i { font-size: 0.9em; }
     .container { padding: 24px; }
+    .stats-container { display: flex; gap: 16px; margin-bottom: 24px; flex-wrap: wrap; }
+    .stat-card { flex: 1; min-width: 120px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 16px; text-align: center; box-shadow: var(--table-shadow); }
+    .stat-number { font-size: 1.8em; font-weight: 700; margin-bottom: 4px; }
+    .stat-label { font-size: 0.85em; font-weight: 600; color: var(--grey); letter-spacing: 1px; }
+    .stat-card.total .stat-number { color: var(--accent); }
+    .stat-card.online .stat-number { color: var(--green); }
+    .stat-card.installing .stat-number { color: var(--orange); }
+    .stat-card.completed .stat-number { color: var(--green); }
     table {
       width: 100%;
       border-collapse: collapse;

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -175,7 +175,9 @@
                 listBody.appendChild(upTr);
             }
             if (data.files.length === 0) {
-                listBody.innerHTML += '<tr><td colspan="3" style="text-align: center; font-style: italic;">Файлы не найдены</td></tr>';
+                const emptyTr = document.createElement('tr');
+                emptyTr.innerHTML = '<td colspan="3" style="text-align: center; font-style: italic;">Файлы не найдены</td>';
+                listBody.appendChild(emptyTr);
                 return;
             }
             data.files.forEach(file => {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -51,6 +51,24 @@
     <div class="log-viewer" id="ansible-log"></div>
   </div>
   <div class="container">
+    <div class="stats-container">
+      <div class="stat-card total">
+        <div class="stat-number">{{ total_hosts }}</div>
+        <div class="stat-label">TOTAL HOSTS</div>
+      </div>
+      <div class="stat-card online">
+        <div class="stat-number">{{ online_hosts }}</div>
+        <div class="stat-label">ONLINE</div>
+      </div>
+      <div class="stat-card installing">
+        <div class="stat-number">{{ installing_hosts }}</div>
+        <div class="stat-label">INSTALLING</div>
+      </div>
+      <div class="stat-card completed">
+        <div class="stat-number">{{ completed_hosts }}</div>
+        <div class="stat-label">COMPLETED</div>
+      </div>
+    </div>
     <table>
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- Fix going up from empty directories in file manager
- Show network host counts in dashboard header

## Testing
- `node --check static/js/dashboard.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a4123c57288327a67f3d6afa5a1d25