### PR TITLE
Track running Ansible tasks via playbook status

### DIFF
--- a/api/ansible.py
+++ b/api/ansible.py
@@ -19,6 +19,7 @@ from services import (
     list_files_in_dir,
     get_ansible_mark,
     create_file_api_handlers,
+    set_playbook_status,
 )
 
 
@@ -138,6 +139,12 @@ def api_ansible_run():
                     ''',
                     (mac, 'playbook.yml', 'running', 0, 10, started),
                 )
+                ip_row = db.execute(
+                    "SELECT ip FROM hosts WHERE mac = ?",
+                    (mac,),
+                ).fetchone()
+                if ip_row and ip_row['ip']:
+                    set_playbook_status(ip_row['ip'], 'running')
         result = subprocess.run(
             ["ansible-playbook", ANSIBLE_PLAYBOOK, "-i", ANSIBLE_INVENTORY],
             capture_output=True,


### PR DESCRIPTION
## Summary
- track Ansible playbook running state using `playbook_status` table
- mark hosts as running before launching ansible-playbook
- suppress "Ansible in progress" when playbook hasn't started

## Testing
- `python -m py_compile services/__init__.py api/ansible.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4190a9b188327b029e8cadc5ae055