### PR TITLE
Add preseed generator with disk and RAID parameters

### DIFF
--- a/api/ipxe.py
+++ b/api/ipxe.py
@@ -11,6 +11,7 @@ from config import (
 )
 from . import api_bp
 from services import read_file, write_file
+from services.preseed_generator import generate_preseed
 import os
 import shutil
 
@@ -94,6 +95,22 @@ def api_preseed_activate():
     except OSError as e:
         logging.error(f'Ошибка при активации preseed файла: {e}')
         return jsonify({'status': 'error', 'msg': str(e)}), 500
+
+
+@api_bp.route('/preseed/generate', methods=['POST'])
+def api_preseed_generate():
+    data = request.get_json(force=True)
+    try:
+        disks = int(data.get('disks', 1))
+        size_gb = int(data.get('size_gb', 10))
+        name = data.get('name') or _active_preseed_name()
+        content = generate_preseed(disks, size_gb)
+        path = _preseed_file_path(name)
+        write_file(path, content)
+        return jsonify({'status': 'ok', 'content': content}), 200
+    except Exception as e:
+        logging.error(f'Ошибка генерации preseed: {e}')
+        return jsonify({'status': 'error', 'msg': str(e)}), 400
 
 
 @api_bp.route('/ipxe', methods=['GET'])

--- a/services/preseed_generator.py
+++ b/services/preseed_generator.py
@@ -1,0 +1,75 @@
+from typing import List
+from textwrap import dedent
+
+
+def _disk_names(count: int) -> List[str]:
+    """Return list of disk device names like /dev/sda, /dev/sdb."""
+    if count < 1:
+        raise ValueError('disk count must be >= 1')
+    return [f"/dev/sd{chr(ord('a') + i)}" for i in range(count)]
+
+
+def generate_preseed(disks: int, size_gb: int) -> str:
+    """Generate preseed file content for the given number of disks and size.
+
+    The resulting preseed config creates RAID1 arrays across all disks for
+    /boot, root and swap. Disk size is specified in gigabytes per disk.
+    """
+    if disks < 1:
+        raise ValueError('disks must be >= 1')
+    if size_gb < 4:
+        raise ValueError('size_gb must be >= 4')
+
+    disk_list = ' '.join(_disk_names(disks))
+    boot_size = 1024  # 1 GiB boot
+    swap_size = 2048  # 2 GiB swap
+    total_mb = size_gb * 1024
+    root_size = total_mb - boot_size - swap_size
+    if root_size <= 0:
+        raise ValueError('disk size too small for partitions')
+
+    expert_recipe = dedent(
+        f"""
+        d-i partman-auto/expert_recipe string \
+            raid :: \
+                {boot_size} {boot_size} {boot_size} raid \\
+                    $primary{{ }} method{{ raid }} \\
+                . \\
+                {root_size} {root_size} {root_size} raid \\
+                    method{{ raid }} \\
+                . \\
+                {swap_size} {swap_size} {swap_size} raid \\
+                    method{{ raid }} \\
+                .
+        """
+    ).strip()
+
+    raid_recipe = dedent(
+        f"""
+        d-i partman-auto-raid/recipe string \
+            1 {disks} 0 ext4 /boot \
+                method{{ raid }} format{{ }} \
+                $primary{{ }} $bootable{{ }} \
+            . \
+            1 {disks} 0 ext4 / \
+                method{{ raid }} format{{ }} \
+            . \
+            1 {disks} 0 linux-swap - \
+                method{{ raid }} format{{ }} \
+            .
+        """
+    ).strip()
+
+    preseed = (
+        "d-i partman-auto/method string raid\n"
+        f"d-i partman-auto/disk string {disk_list}\n"
+        f"{expert_recipe}\n"
+        f"{raid_recipe}\n"
+        "d-i mdadm/boot_degraded string true\n"
+        "d-i partman-md/device_remove_md boolean true\n"
+        "d-i partman-md/device_remove_lvm boolean true\n"
+        "d-i partman/confirm_write_new_label boolean true\n"
+        "d-i partman/confirm boolean true\n"
+        "d-i partman/confirm_nooverwrite boolean true\n"
+    )
+    return preseed

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -156,6 +156,9 @@
     .modal header { background: var(--accent); color: #fff; padding: 10px 16px; display: flex; justify-content: space-between; align-items: center; flex-shrink: 0; }
     #preseed-modal .preseed-top-controls { padding: 12px; display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
     #preseed-modal .preseed-top-controls select { flex: 1; }
+    #preseed-modal .preseed-generator { padding: 12px; display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+    #preseed-modal .preseed-generator label { display: flex; gap: 4px; align-items: center; }
+    #preseed-modal .preseed-generator input { width: 80px; }
     #playbook-editor-container { flex: 1; overflow: hidden; position: relative; }
     #playbook-editor { height: 100%; width: 100%; }
     .CodeMirror { height: 100% !important; font-family: 'Fira Code', monospace !important; font-size: 14px !important; line-height: 1.5 !important; margin: 0 !important; padding: 0 !important; }

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -245,6 +245,25 @@
         alert('Ошибка создания: ' + e.message);
       }
     };
+
+    document.getElementById('preseed-generate').onclick = async () => {
+      const name = document.getElementById('preseed-select').value;
+      const disks = parseInt(document.getElementById('preseed-disk-count').value, 10);
+      const size = parseInt(document.getElementById('preseed-disk-size').value, 10);
+      try {
+        const res = await fetch('/api/preseed/generate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, disks, size_gb: size })
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.msg);
+        document.getElementById('preseed-content').value = data.content;
+        alert('Preseed сгенерирован.');
+      } catch (e) {
+        alert('Ошибка генерации: ' + e.message);
+      }
+    };
     let currentFilesPath = '';
     const baseFilesPath = document.getElementById('files-modal-title').textContent.replace(/^Файлы\s*/, '');
     async function loadFilesList() {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -122,6 +122,11 @@
       <button class="btn" id="preseed-add"><i class="fa fa-plus"></i></button>
       <button class="btn" id="preseed-activate"><i class="fa fa-check"></i> Активировать</button>
     </div>
+    <div class="preseed-generator">
+      <label>Диски: <input type="number" id="preseed-disk-count" min="1" value="1"></label>
+      <label>Объём ГБ: <input type="number" id="preseed-disk-size" min="4" value="100"></label>
+      <button class="btn" id="preseed-generate"><i class="fa fa-cogs"></i> Сгенерировать</button>
+    </div>
     <textarea id="preseed-content" readonly></textarea>
     <div class="controls">
       <button class="btn" id="edit-preseed-btn"><i class="fa fa-edit"></i> Редактировать</button>


### PR DESCRIPTION
## Summary
- add server-side generator for RAID preseed files based on disk count and size
- expose `/api/preseed/generate` to save generated config and return content
- extend dashboard UI with inputs for disks and size and generation button

## Testing
- `python -m py_compile api/ipxe.py services/preseed_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4265317088327940cd632b36b6084