### PR TITLE
Add parametric preseed disk generator

### DIFF
--- a/api/ipxe.py
+++ b/api/ipxe.py
@@ -11,6 +11,7 @@ from config import (
 )
 from . import api_bp
 from services import read_file, write_file
+from services.preseed_generator import update_disk_layout
 import os
 import shutil
 
@@ -94,6 +95,22 @@ def api_preseed_activate():
     except OSError as e:
         logging.error(f'Ошибка при активации preseed файла: {e}')
         return jsonify({'status': 'error', 'msg': str(e)}), 500
+
+
+@api_bp.route('/preseed/generate', methods=['POST'])
+def api_preseed_generate():
+    """Modify disk layout inside an existing preseed file in-place."""
+    data = request.get_json(force=True)
+    try:
+        disks = int(data.get('disks', 1))
+        size = int(data.get('size_gb', 0))
+        name = data.get('name') or _active_preseed_name()
+        path = _preseed_file_path(name)
+        summary = update_disk_layout(path, disks, size)
+        return jsonify({'status': 'ok', 'summary': summary}), 200
+    except Exception as e:
+        logging.error(f'Ошибка генерации preseed: {e}')
+        return jsonify({'status': 'error', 'msg': str(e)}), 400
 
 
 @api_bp.route('/ipxe', methods=['GET'])

--- a/services/preseed_generator.py
+++ b/services/preseed_generator.py
@@ -1,0 +1,70 @@
+"""Utilities for updating preseed files with dynamic disk layouts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+def _disk_names(count: int) -> List[str]:
+    """Return list of disk device names (/dev/sda, /dev/sdb, ...)."""
+    return [f"/dev/sd{chr(ord('a') + i)}" for i in range(count)]
+
+
+def update_disk_layout(path: str, disks: int, size_gb: int) -> str:
+    """Update disk and RAID layout inside existing preseed file.
+
+    The function searches for common partman directives and updates them in place.
+    Only lines describing disk list and raid method are touched; the rest of the
+    file is left intact.  A short summary of calculated partition sizes is
+    returned as a string.
+
+    Parameters
+    ----------
+    path: str
+        Path to preseed file that should be edited in-place.
+    disks: int
+        Number of disks that should participate in the installation.
+    size_gb: int
+        Size of each disk in gigabytes.  All disks are assumed to be equal.
+    """
+
+    if disks <= 0:
+        raise ValueError("disks must be positive")
+    if size_gb <= 0:
+        raise ValueError("size_gb must be positive")
+
+    file_path = Path(path)
+    lines = file_path.read_text(encoding="utf-8").splitlines()
+
+    devices = _disk_names(disks)
+    disk_line = f"d-i partman-auto/disk string {' '.join(devices)}"
+    method_line = "d-i partman-auto/method string raid" if disks > 1 else "d-i partman-auto/method string regular"
+
+    updated: List[str] = []
+    for line in lines:
+        if line.startswith("d-i partman-auto/disk string"):
+            updated.append(disk_line)
+        elif line.startswith("d-i partman-auto/method string"):
+            updated.append(method_line)
+        else:
+            updated.append(line)
+
+    file_path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+
+    # calculate partition summary: allocate 1G boot, 1G swap, rest root.
+    boot = 1
+    swap = 1
+    root = size_gb - boot - swap
+    if root < 0:
+        root = 0
+
+    summary = [f"Disks: {', '.join(devices)}", f"/boot: {boot}G each", f"swap: {swap}G each"]
+    if disks > 1:
+        summary.append(f"root (RAID1): {root}G")
+    else:
+        summary.append(f"root: {root}G")
+    return "\n".join(summary)
+
+
+__all__ = ["update_disk_layout"]

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -245,6 +245,26 @@
         alert('Ошибка создания: ' + e.message);
       }
     };
+
+    document.getElementById('preseed-generate').onclick = async () => {
+      const disks = parseInt(prompt('Количество дисков:'), 10);
+      const size = parseInt(prompt('Размер одного диска (ГБ):'), 10);
+      if (!disks || !size) return;
+      const name = document.getElementById('preseed-select').value;
+      try {
+        const res = await fetch('/api/preseed/generate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, disks, size_gb: size })
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.msg);
+        await loadPreseedContent();
+        alert(data.summary);
+      } catch (e) {
+        alert('Ошибка генерации: ' + e.message);
+      }
+    };
     let currentFilesPath = '';
     const baseFilesPath = document.getElementById('files-modal-title').textContent.replace(/^Файлы\s*/, '');
     async function loadFilesList() {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -121,6 +121,7 @@
       <select id="preseed-select"></select>
       <button class="btn" id="preseed-add"><i class="fa fa-plus"></i></button>
       <button class="btn" id="preseed-activate"><i class="fa fa-check"></i> Активировать</button>
+      <button class="btn" id="preseed-generate"><i class="fa fa-cogs"></i> Генерировать</button>
     </div>
     <textarea id="preseed-content" readonly></textarea>
     <div class="controls">


### PR DESCRIPTION
## Summary
- add `update_disk_layout` utility to alter disk lines inside a preseed file
- expose `/api/preseed/generate` to update active preseed with new disk/size parameters
- add dashboard button that prompts for disks and size and regenerates layout in place

## Testing
- `python -m py_compile services/preseed_generator.py api/ipxe.py`
- `python - <<'PY'
from services.preseed_generator import update_disk_layout
summary = update_disk_layout('/tmp/preseed.cfg', 2, 100)
print('SUMMARY:', summary)
print('UPDATED:\n', open('/tmp/preseed.cfg').read())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a429a3b1d48327aca99aef191f2072