### PR TITLE
feat: add controls for Ansible log viewer

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -165,6 +165,9 @@
     .modal textarea:not(#playbook-content) { flex: 1; padding: 12px; font-family: monospace; font-size: 13px; background: #1e1e1e; color: #eee; border: none; resize: none; }
     .controls { padding: 12px; display: flex; gap: 8px; justify-content: flex-end; flex-shrink: 0; }
     .log-viewer { flex: 1; background: #1e1e1e; color: #ddd; font-family: monospace; font-size: 14px; padding: 12px; overflow-y: auto; white-space: pre-wrap; border-top: 1px solid var(--border); line-height: 1.6; }
+    .log-controls { display:flex; gap:8px; align-items:center; margin:8px 0; }
+    .log-controls input { width:70px; padding:4px; font-family: monospace; }
+    #ansible-log.collapsed { display:none; }
     .file-list-simple-container { flex: 1; padding: 16px; overflow-y: auto; }
     .file-simple-table { width: 100%; border-collapse: collapse; background: var(--bg); color: var(--text); font-size: 0.9em; }
     .file-simple-table th, .file-simple-table td { padding: 10px 14px; text-align: left; border-bottom: 1px solid var(--border); }

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -321,25 +321,38 @@
     document.getElementById('toggle-ansible').onclick = () => {
       const p = document.getElementById('ansible-panel');
       p.style.display = p.style.display === 'none' ? 'block' : 'none';
-      if (p.style.display === 'block') loadAnsibleLog();
+      if (p.style.display === 'block') loadAnsibleLog(true);
     };
-    async function loadAnsibleLog() {
+    const ansibleLogEl = document.getElementById('ansible-log');
+    let ansibleLogLines = 100;
+    document.getElementById('ansible-log-collapse').onclick = () => {
+      ansibleLogEl.classList.toggle('collapsed');
+    };
+    document.getElementById('ansible-log-refresh').onclick = () => loadAnsibleLog(true);
+    document.getElementById('ansible-log-lines').onchange = (e) => {
+      const val = parseInt(e.target.value, 10);
+      ansibleLogLines = !isNaN(val) ? val : 100;
+      loadAnsibleLog(true);
+    };
+    document.getElementById('ansible-log-top').onclick = () => ansibleLogEl.scrollTop = 0;
+    document.getElementById('ansible-log-bottom').onclick = () => ansibleLogEl.scrollTop = ansibleLogEl.scrollHeight;
+    async function loadAnsibleLog(forceScroll = false) {
+      if (ansibleLogEl.classList.contains('collapsed')) return;
       try {
-        const res = await fetch('/api/logs/ansible');
+        const res = await fetch(`/api/logs/ansible?lines=${ansibleLogLines}`);
         const lines = await res.json();
-        const logEl = document.getElementById('ansible-log');
-        logEl.innerHTML = '';
+        ansibleLogEl.innerHTML = '';
         lines.forEach(line => {
             const div = document.createElement('div');
             div.innerHTML = line;
-            logEl.appendChild(div);
+            ansibleLogEl.appendChild(div);
         });
-        setTimeout(() => logEl.scrollTop = logEl.scrollHeight, 0);
+        if (forceScroll) setTimeout(() => ansibleLogEl.scrollTop = ansibleLogEl.scrollHeight, 0);
       } catch (e) {
-        document.getElementById('ansible-log').innerHTML = `<span style="color:#ff6b6b">Ошибка: ${e.message}</span>`;
+        ansibleLogEl.innerHTML = `<span style="color:#ff6b6b">Ошибка: ${e.message}</span>`;
       }
     }
-    setInterval(loadAnsibleLog, 3000);
+    setInterval(() => loadAnsibleLog(), 3000);
     document.getElementById('hosts-table-body').addEventListener('click', async (e) => {
       if (e.target.closest('.btn-reboot')) {
         const ip = e.target.closest('.btn-reboot').dataset.ip;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -48,6 +48,13 @@
       <button class="btn" id="manage-files"><i class="fa fa-folder"></i> Файлы</button>
     </div>
     <h4><i class="fa fa-terminal"></i> Журнал выполнения Ansible</h4>
+    <div class="log-controls">
+      <button class="btn" id="ansible-log-collapse" title="Свернуть/развернуть"><i class="fa fa-chevron-up"></i></button>
+      <label>Строк: <input type="number" id="ansible-log-lines" value="100" min="10" max="1000" step="10"></label>
+      <button class="btn" id="ansible-log-refresh" title="Обновить"><i class="fa fa-sync-alt"></i></button>
+      <button class="btn" id="ansible-log-top" title="В начало"><i class="fa fa-arrow-up"></i></button>
+      <button class="btn" id="ansible-log-bottom" title="В конец"><i class="fa fa-arrow-down"></i></button>
+    </div>
     <div class="log-viewer" id="ansible-log"></div>
   </div>
   <div class="container">


### PR DESCRIPTION
## Summary
- add toolbar to Ansible log section with collapse, refresh, line count and navigation buttons
- allow API to return a selectable number of Ansible log lines
- support new UI with CSS and JavaScript updates

## Testing
- `python -m py_compile api/ansible.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4303fb13c83278115b069a2c69bc1