### PR TITLE
Ensure panel reflects historical Ansible runs

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -70,26 +70,38 @@ def parse_ansible_logs():
         logging.info("Начинаем анализ логов Ansible...")
         try:
             result = subprocess.run(
-                ['journalctl', '-u', ANSIBLE_SERVICE_NAME, '-n', '500', '--no-pager', '--since', '5 minutes ago'],
+                [
+                    'journalctl',
+                    '-u',
+                    ANSIBLE_SERVICE_NAME,
+                    '-n',
+                    '1000',
+                    '--no-pager',
+                    '--output',
+                    'short-iso',
+                ],
                 capture_output=True,
                 text=True,
                 check=True,
             )
             lines = result.stdout.strip().split('\n')
             new_lines = [line for line in lines if line not in last_checked_lines]
-            last_checked_lines.update(new_lines[-100:])
+            last_checked_lines.update(new_lines[-1000:])
             ip_status_map = {}
             for line in reversed(new_lines):
                 if 'PLAY RECAP' in line:
                     continue
-                recap_match = re.search(r'(\d+\.\d+\.\d+\.\d+)\s*:.*?failed=(\d+)', line)
+                recap_match = re.search(
+                    r'^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}).*?(\d+\.\d+\.\d+\.\d+)\s*:.*?failed=(\d+)',
+                    line,
+                )
                 if recap_match:
-                    ip = recap_match.group(1)
-                    failed_count = int(recap_match.group(2))
-                    if ip not in ip_status_map:
-                        ip_status_map[ip] = 'failed' if failed_count > 0 else 'ok'
-            for ip, status in ip_status_map.items():
-                set_playbook_status(ip, status)
+                    ts_str, ip, failed_str = recap_match.groups()
+                    status = 'failed' if int(failed_str) > 0 else 'ok'
+                    ts = datetime.datetime.fromisoformat(ts_str)
+                    ip_status_map[ip] = {'status': status, 'ts': ts}
+            for ip, data in ip_status_map.items():
+                set_playbook_status(ip, data['status'], data['ts'].strftime('%Y-%m-%d %H:%M:%S'))
             if ip_status_map:
                 logging.info(
                     f"Статусы Ansible обновлены для IP: {list(ip_status_map.keys())}"


### PR DESCRIPTION
## Summary
- track Ansible playbook status timestamps and persist them
- parse older journal entries to recover host completion state
- fall back to stored status when ansible_mark.json is missing

## Testing
- `python -m py_compile services/__init__.py tasks/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a439777f748327a06aca8b3106412b