### PR TITLE
feat: track ansible completion and parse historical logs

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -70,7 +70,7 @@ def parse_ansible_logs():
         logging.info("Начинаем анализ логов Ansible...")
         try:
             result = subprocess.run(
-                ['journalctl', '-u', ANSIBLE_SERVICE_NAME, '-n', '500', '--no-pager', '--since', '5 minutes ago'],
+                ['journalctl', '-u', ANSIBLE_SERVICE_NAME, '-n', '1000', '--no-pager'],
                 capture_output=True,
                 text=True,
                 check=True,


### PR DESCRIPTION
## Summary
- derive Ansible completion info from local database when mark.json isn't available
- parse more journalctl history to populate playbook status for older runs

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a439777f748327a06aca8b3106412b