### PR TITLE
feat: track ansible completion time

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -4,6 +4,7 @@ import subprocess
 import datetime
 import re
 import json
+from typing import Optional
 from flask import jsonify, abort, request
 
 from config import (
@@ -74,8 +75,22 @@ def list_files_in_dir(directory: str):
     return file_list
 
 
-def set_playbook_status(ip: str, status: str) -> None:
-    """Store Ansible playbook status for host."""
+def set_playbook_status(ip: str, status: str, updated: Optional[str] = None) -> None:
+    """Store Ansible playbook status for host.
+
+    Parameters
+    ----------
+    ip: str
+        Target host IP address.
+    status: str
+        Status string (e.g. ``running``, ``ok``, ``failed``).
+    updated: Optional[str]
+        Timestamp in ``'%Y-%m-%d %H:%M:%S'`` format. If omitted the current
+        UTC time is used.
+    """
+
+    if updated is None:
+        updated = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
     try:
         with get_db() as db:
             db.execute(
@@ -86,9 +101,11 @@ def set_playbook_status(ip: str, status: str) -> None:
                   status = excluded.status,
                   updated = excluded.updated
                 ''',
-                (ip, status, datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')),
+                (ip, status, updated),
             )
-        logging.info(f"Статус Ansible для {ip} установлен в '{status}'")
+        logging.info(
+            f"Статус Ansible для {ip} установлен в '{status}' в {updated}"
+        )
     except Exception as e:
         logging.error(
             f"Ошибка при установке статуса Ansible для {ip}: {e}", exc_info=True
@@ -96,16 +113,22 @@ def set_playbook_status(ip: str, status: str) -> None:
 
 
 def get_ansible_mark(ip: str):
-    """Fetch /opt/ansible_mark.json from remote host via SSH."""
+    """Fetch ``/opt/ansible_mark.json`` from remote host via SSH.
+
+    Falls back to the locally stored ``playbook_status`` information when the
+    remote mark file is unavailable. This allows the dashboard to display
+    completion timestamps even for hosts provisioned before the dashboard was
+    introduced.
+    """
     if not re.match(r'^\d{1,3}(\.\d{1,3}){3}$', ip) or ip == '—':
         return {'status': 'error', 'msg': 'Invalid IP'}
     try:
-        # First check local playbook_status to see if Ansible is running
         with get_db() as db:
             row = db.execute(
-                "SELECT status FROM playbook_status WHERE ip = ?",
+                "SELECT status, updated FROM playbook_status WHERE ip = ?",
                 (ip,),
             ).fetchone()
+
         if row and row['status'] == 'running':
             return {'status': 'pending', 'msg': 'Ansible playbook is running'}
 
@@ -116,23 +139,49 @@ def get_ansible_mark(ip: str):
         result = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=10
         )
-        if result.returncode != 0:
-            if "No such file" in result.stderr:
+        if result.returncode == 0:
+            try:
+                data = json.loads(result.stdout)
+                data['status'] = 'ok'
+                # If install_date missing, fall back to DB record if available
+                if 'install_date' not in data and row and row['status'] == 'ok':
+                    data['install_date'] = row['updated']
+                return data
+            except json.JSONDecodeError as e:
+                logging.warning(
+                    f"Некорректный JSON в mark.json для {ip}: {e}"
+                )
+                if row and row['status'] in {'ok', 'failed'}:
+                    return {
+                        'status': row['status'],
+                        'install_date': row['updated'],
+                        'msg': 'Некорректный JSON в mark.json',
+                    }
                 return {
-                    'status': 'none',
-                    'msg': 'Файл mark.json не найден',
+                    'status': 'error',
+                    'msg': f'Некорректный JSON в mark.json: {str(e)}',
                 }
-            return {'status': 'error', 'msg': f"SSH ошибка: {result.stderr.strip()}"}
-        try:
-            data = json.loads(result.stdout)
-            data['status'] = 'ok'
-            return data
-        except json.JSONDecodeError as e:
+
+        # SSH returned non-zero exit code
+        if row and row['status'] in {'ok', 'failed'}:
             return {
-                'status': 'error',
-                'msg': f'Некорректный JSON в mark.json: {str(e)}',
+                'status': row['status'],
+                'install_date': row['updated'],
             }
+        if "No such file" in result.stderr:
+            return {
+                'status': 'none',
+                'msg': 'Файл mark.json не найден',
+            }
+        return {'status': 'error', 'msg': f"SSH ошибка: {result.stderr.strip()}"}
+
     except subprocess.TimeoutExpired:
+        if row and row['status'] in {'ok', 'failed'}:
+            return {
+                'status': row['status'],
+                'install_date': row['updated'],
+                'msg': 'Таймаут подключения к хосту',
+            }
         return {'status': 'error', 'msg': 'Таймаут подключения к хосту'}
     except Exception as e:
         return {'status': 'error', 'msg': f'Внутренняя ошибка: {str(e)}'}

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -65,34 +65,55 @@ def ping_hosts_background():
 def parse_ansible_logs():
     """Background task parsing Ansible logs and updating statuses."""
     last_checked_lines = set()
+    first_run = True
     while True:
         time.sleep(30)
         logging.info("Начинаем анализ логов Ansible...")
         try:
+            since = '1 year ago' if first_run else '5 minutes ago'
+            first_run = False
             result = subprocess.run(
-                ['journalctl', '-u', ANSIBLE_SERVICE_NAME, '-n', '500', '--no-pager', '--since', '5 minutes ago'],
+                [
+                    'journalctl',
+                    '-u',
+                    ANSIBLE_SERVICE_NAME,
+                    '--no-pager',
+                    '--since',
+                    since,
+                    '-o',
+                    'short-iso',
+                ],
                 capture_output=True,
                 text=True,
                 check=True,
             )
-            lines = result.stdout.strip().split('\n')
+            lines = result.stdout.strip().split('\n') if result.stdout else []
             new_lines = [line for line in lines if line not in last_checked_lines]
-            last_checked_lines.update(new_lines[-100:])
+            last_checked_lines.update(new_lines[-500:])
             ip_status_map = {}
             for line in reversed(new_lines):
                 if 'PLAY RECAP' in line:
                     continue
-                recap_match = re.search(r'(\d+\.\d+\.\d+\.\d+)\s*:.*?failed=(\d+)', line)
+                recap_match = re.search(
+                    r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}).*(\d+\.\d+\.\d+\.\d+)\s*:.*?failed=(\d+)',
+                    line,
+                )
                 if recap_match:
-                    ip = recap_match.group(1)
-                    failed_count = int(recap_match.group(2))
+                    ts_iso, ip, failed_str = recap_match.groups()
+                    failed_count = int(failed_str)
                     if ip not in ip_status_map:
-                        ip_status_map[ip] = 'failed' if failed_count > 0 else 'ok'
-            for ip, status in ip_status_map.items():
-                set_playbook_status(ip, status)
+                        status = 'failed' if failed_count > 0 else 'ok'
+                        ts = (
+                            datetime.datetime.fromisoformat(ts_iso)
+                            .strftime('%Y-%m-%d %H:%M:%S')
+                        )
+                        ip_status_map[ip] = (status, ts)
+            for ip, (status, ts) in ip_status_map.items():
+                set_playbook_status(ip, status, ts)
             if ip_status_map:
                 logging.info(
-                    f"Статусы Ansible обновлены для IP: {list(ip_status_map.keys())}"
+                    "Статусы Ansible обновлены для IP: %s",
+                    list(ip_status_map.keys()),
                 )
         except subprocess.CalledProcessError as e:
             logging.warning(


### PR DESCRIPTION
## Summary
- capture ansible run status and completion time from journalctl
- fall back to stored status when ansible_mark.json is missing

## Testing
- `python -m py_compile services/__init__.py tasks/__init__.py web/__init__.py api/ansible.py`


------
https://chatgpt.com/codex/tasks/task_e_68a439777f748327a06aca8b3106412b