### PR TITLE
use server timestamp for ansible status

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -136,6 +136,11 @@ def get_ansible_mark(ip: str):
             try:
                 data = json.loads(result.stdout)
                 data['status'] = 'ok'
+                # Replace timestamp with locally recorded value to avoid
+                # discrepancies caused by incorrect time settings on the host
+                # where ``ansible_mark.json`` is generated.
+                if db_updated:
+                    data['install_date'] = db_updated
                 return data
             except json.JSONDecodeError as e:
                 return {


### PR DESCRIPTION
## Summary
- ensure ansible status uses local server timestamp from the database instead of remote host time

## Testing
- `python -m py_compile services/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68a43ee28fe88327b15277b8ae0357d4