### PR TITLE
Sync hosts from inventory after DB reset

### DIFF
--- a/web/__init__.py
+++ b/web/__init__.py
@@ -4,12 +4,13 @@ import logging
 
 from config import LOCAL_OFFSET, ANSIBLE_FILES_DIR
 from db_utils import get_db
-from services import get_ansible_mark
+from services import get_ansible_mark, sync_inventory_hosts
 
 web_bp = Blueprint('web', __name__)
 
 @web_bp.route('/')
 def dashboard():
+    sync_inventory_hosts()
     db = get_db()
     rows = db.execute('''
         SELECT h.mac, h.ip, h.stage, h.details, h.ts,


### PR DESCRIPTION
## Summary
- sync missing hosts from Ansible inventory into DB
- load inventory hosts automatically on dashboard load

## Testing
- `python -m py_compile services/__init__.py web/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4431e805c8327af5ae2699cd111ae