### PR TITLE
Sync hosts from inventory after DB reset

### DIFF
--- a/api/hosts.py
+++ b/api/hosts.py
@@ -11,6 +11,7 @@ from config import (
 )
 from . import api_bp
 from services.registration import register_host
+from services import sync_inventory_hosts
 
 
 @api_bp.route('/register', methods=['GET', 'POST'])
@@ -37,6 +38,16 @@ def api_register():
     except Exception as e:
         logging.error(f'Ошибка запуска playbook: {e}')
     return 'OK', 200
+
+
+@api_bp.route('/hosts/refresh', methods=['POST'])
+def api_hosts_refresh():
+    try:
+        sync_inventory_hosts()
+        return jsonify({'status': 'ok'}), 200
+    except Exception as e:
+        logging.error(f'Ошибка синхронизации инвентаря: {e}')
+        return jsonify({'status': 'error', 'msg': 'Failed to sync inventory'}), 500
 
 
 @api_bp.route('/host/reboot', methods=['POST'])

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -309,6 +309,15 @@
         textarea.value = `dhcp-host=${mac},${ip},12h\n${textarea.value}`;
       }
     };
+    document.getElementById('refresh-hosts').onclick = async () => {
+      try {
+        const res = await fetch('/api/hosts/refresh', { method: 'POST' });
+        if (!res.ok) throw new Error((await res.json()).msg);
+        await refreshTable();
+      } catch (e) {
+        alert('Ошибка: ' + e.message);
+      }
+    };
     document.getElementById('clear-db').onclick = async () => {
       if (!confirm('Удалить базу данных?')) return;
       try {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -33,13 +33,14 @@
         <button class="btn" id="edit-dnsmasq"><i class="fa fa-network-wired"></i> DHCP / iPXE</button>
         <button class="btn" id="edit-ipxe"><i class="fa fa-code"></i> iPXE</button>
       </div>
-      <div class="divider"></div>
-      <div class="header-group">
-        <button class="btn btn-danger" id="clear-db"><i class="fa fa-trash"></i> Очистить</button>
-        <button class="btn" id="toggle-ansible"><i class="fa fa-robot"></i> Ansible</button>
+        <div class="divider"></div>
+        <div class="header-group">
+          <button class="btn" id="refresh-hosts"><i class="fa fa-sync"></i> Обновить</button>
+          <button class="btn btn-danger" id="clear-db"><i class="fa fa-trash"></i> Очистить</button>
+          <button class="btn" id="toggle-ansible"><i class="fa fa-robot"></i> Ansible</button>
+        </div>
       </div>
-    </div>
-  </header>
+    </header>
   <div id="ansible-panel" style="margin: 24px 0; padding: 16px; border-radius: 8px; background: var(--bg); border: 1px solid var(--border); display: none;">
     <h3><i class="fa fa-robot"></i> Ansible</h3>
     <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;">

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -4,12 +4,13 @@ import logging
 
 from config import LOCAL_OFFSET, ANSIBLE_FILES_DIR
 from db_utils import get_db
-from services import get_ansible_mark
+from services import get_ansible_mark, sync_inventory_hosts
 
 web_bp = Blueprint('web', __name__)
 
 @web_bp.route('/')
 def dashboard():
+    sync_inventory_hosts()
     db = get_db()
     rows = db.execute('''
         SELECT h.mac, h.ip, h.stage, h.details, h.ts,


### PR DESCRIPTION
## Summary
- parse Ansible inventory manually to sync hosts reliably
- expose `/api/hosts/refresh` and UI button to manually refresh hosts

## Testing
- `python -m py_compile services/__init__.py api/hosts.py web/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4431e805c8327af5ae2699cd111ae