### PR TITLE
Add manual refresh button to host dashboard

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -328,6 +328,8 @@
         loadAnsibleLog();
       }
     };
+    const refreshBtn = document.getElementById('refresh-hosts');
+    if (refreshBtn) refreshBtn.onclick = refreshTable;
     async function loadAnsibleLog() {
       try {
         const res = await fetch(`/api/logs/ansible?limit=${ansibleLogLimit}`);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -37,6 +37,7 @@
       <div class="header-group">
         <button class="btn btn-danger" id="clear-db"><i class="fa fa-trash"></i> Очистить</button>
         <button class="btn" id="toggle-ansible"><i class="fa fa-robot"></i> Ansible</button>
+        <button class="btn" id="refresh-hosts"><i class="fa fa-sync-alt"></i> Обновить</button>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- add "Обновить" button to reload host list manually
- wire up button to existing refreshTable logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a452464c80832798ed484432c176bc