### PR TITLE
Start background threads during app init

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,11 +16,10 @@ def create_app() -> Flask:
     app.register_blueprint(logtail_bp)
     app.register_blueprint(api_bp)
     app.register_blueprint(web_bp)
-
+    start_background_tasks()
     return app
 
 
 app = create_app()
 if __name__ == '__main__':
-    start_background_tasks()
     app.run(host='0.0.0.0', port=5000)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -9,6 +9,9 @@ from config import ANSIBLE_SERVICE_NAME
 from db_utils import get_db
 from services import set_playbook_status
 
+# Ensure background threads start only once
+_tasks_started = False
+
 
 def ping_host(ip: str) -> bool:
     """Ping host and return True if reachable."""
@@ -126,5 +129,9 @@ def parse_ansible_logs():
             )
 def start_background_tasks() -> None:
     """Start all background threads."""
+    global _tasks_started
+    if _tasks_started:
+        return
+    _tasks_started = True
     threading.Thread(target=ping_hosts_background, daemon=True).start()
     threading.Thread(target=parse_ansible_logs, daemon=True).start()


### PR DESCRIPTION
## Summary
- Launch background tasks when the Flask app is created so Ansible statuses are recorded
- Prevent background threads from starting multiple times

## Testing
- `python -m py_compile app.py tasks/__init__.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log || tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a45c30a464832797f4c36c3633fb8c