### PR TITLE
Ensure Ansible runs from playbook directory

### DIFF
--- a/api/ansible.py
+++ b/api/ansible.py
@@ -140,6 +140,7 @@ def api_ansible_tags():
             capture_output=True,
             text=True,
             check=True,
+            cwd=os.path.dirname(ANSIBLE_PLAYBOOK),
         )
         tags = set()
         for line in result.stdout.splitlines():
@@ -184,7 +185,12 @@ def api_ansible_run():
         cmd = ["ansible-playbook", ANSIBLE_PLAYBOOK, "-i", ANSIBLE_INVENTORY]
         if tags:
             cmd.extend(["--tags", ",".join(tags)])
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=os.path.dirname(ANSIBLE_PLAYBOOK),
+        )
 
         # Ignore warnings about collections not supporting the current Ansible version.
         # These warnings are emitted on stderr and previously caused the API to

--- a/api/hosts.py
+++ b/api/hosts.py
@@ -1,6 +1,7 @@
 from flask import request, jsonify
 import subprocess
 import logging
+import os
 
 from config import (
     SSH_PASSWORD,
@@ -32,7 +33,7 @@ def api_register():
             ANSIBLE_PLAYBOOK,
             "-i",
             ANSIBLE_INVENTORY,
-        ])
+        ], cwd=os.path.dirname(ANSIBLE_PLAYBOOK))
         logging.info(f'Ansible-playbook запущен для MAC {mac}')
     except Exception as e:
         logging.error(f'Ошибка запуска playbook: {e}')


### PR DESCRIPTION
## Summary
- run ansible-playbook commands with cwd set to the playbook directory
- ensure host registration launches playbook from proper cwd

## Testing
- `python -m pytest`
- `python -m py_compile api/ansible.py api/hosts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a55a6e0cc88327b494f70a8f0e3a29