### PR TITLE
Stream ansible logs to web UI

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -358,6 +358,7 @@
         const data = await res.json();
         if (!res.ok) throw new Error(data.msg || 'Ошибка запуска');
         alert('Запуск инициирован');
+        loadAnsibleLog();
       } catch (e) {
         alert('Ошибка запуска: ' + e.message);
       }


### PR DESCRIPTION
## Summary
- stream `ansible-playbook` stdout/stderr to journald so log viewer updates in real time
- refresh Ansible log panel immediately after triggering a run

## Testing
- `python -m py_compile api/ansible.py`
- `node --check static/js/dashboard.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a561bf4acc8327b022c6ee44e2d7cd