### PR TITLE
Stream Ansible playbook output to logs

### DIFF
--- a/api/ansible.py
+++ b/api/ansible.py
@@ -161,28 +161,53 @@ def api_ansible_tags():
 
 
 def _run_playbook_async(tags, started):
-    """Execute ansible-playbook in a background thread and update statuses."""
+    """Execute ansible-playbook and stream its output to the logs."""
     cmd = ["ansible-playbook", ANSIBLE_PLAYBOOK, "-i", ANSIBLE_INVENTORY]
     if tags:
         cmd.extend(["--tags", ",".join(tags)])
-    result = subprocess.run(cmd, capture_output=True, text=True)
 
-    # Forward stdout/stderr to journald for visibility in the web UI.
-    for line in result.stdout.splitlines():
-        logging.info(line)
-
-    # Ignore warnings about collections not supporting the current Ansible version.
     warning_re = re.compile(
         r"^\[WARNING\]: Collection .* does not support Ansible (?:version|action)"
     )
-    stderr_lines = result.stderr.splitlines() if result.stderr else []
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+    stdout_lines = []
+    stderr_lines = []
+
+    def _stream(pipe, log_func, collector, skip_re=None):
+        for line in iter(pipe.readline, ""):
+            if skip_re and skip_re.match(line):
+                collector.append(line)
+                continue
+            log_func(line.rstrip())
+            collector.append(line)
+        pipe.close()
+
+    out_thread = threading.Thread(
+        target=_stream, args=(proc.stdout, logging.info, stdout_lines)
+    )
+    err_thread = threading.Thread(
+        target=_stream,
+        args=(proc.stderr, logging.error, stderr_lines, warning_re),
+    )
+    out_thread.start()
+    err_thread.start()
+    proc.wait()
+    out_thread.join()
+    err_thread.join()
+
     non_warning_lines = [line for line in stderr_lines if not warning_re.match(line)]
-    for line in non_warning_lines:
-        logging.error(line)
 
     ip_status_map = {}
     recap_started = False
-    for line in result.stdout.splitlines():
+    for line in stdout_lines:
         if line.strip().startswith("PLAY RECAP"):
             recap_started = True
             continue
@@ -190,7 +215,7 @@ def _run_playbook_async(tags, started):
             match = re.search(r"(\d+\.\d+\.\d+\.\d+).*failed=(\d+)", line)
             if match:
                 ip, failed = match.groups()
-                ip_status_map[ip] = 'failed' if int(failed) > 0 else 'ok'
+                ip_status_map[ip] = "failed" if int(failed) > 0 else "ok"
     if ip_status_map:
         with get_db() as db:
             for ip, status in ip_status_map.items():
@@ -205,9 +230,9 @@ def _run_playbook_async(tags, started):
                         SET status=?, step=10
                         WHERE mac=? AND started_at=?
                         """,
-                        (status, mac_row['mac'], started),
+                        (status, mac_row["mac"], started),
                     )
-    if result.returncode == 0:
+    if proc.returncode == 0:
         if non_warning_lines:
             logging.warning(
                 "ansible-playbook completed with warnings: %s",
@@ -221,10 +246,10 @@ def _run_playbook_async(tags, started):
         else:
             logging.info("ansible-playbook completed successfully")
     else:
-        error_msg = "\n".join(non_warning_lines) if non_warning_lines else result.stderr
+        error_msg = "\n".join(non_warning_lines) if non_warning_lines else "".join(stderr_lines)
         logging.error(
             "ansible-playbook failed with code %s: %s",
-            result.returncode,
+            proc.returncode,
             error_msg,
         )
 


### PR DESCRIPTION
## Summary
- Stream ansible-playbook stdout and stderr to the Flask logger so the UI can show live log updates
- Preserve existing status parsing and ignore known collection warnings

## Testing
- `python -m pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a561bf4acc8327b022c6ee44e2d7cd