### PR TITLE
Handle colored Ansible recap output

### DIFF
--- a/api/hosts.py
+++ b/api/hosts.py
@@ -30,6 +30,11 @@ def parse_playbook_summary(output: str) -> dict[str, str]:
     if "PLAY RECAP" not in output:
         return result
 
+    # Удаляем управляющие ANSI-последовательности, которые Ansible
+    # добавляет для цветного вывода.  В противном случае имена хостов
+    # могут содержать escape-коды и не совпадать с IP-адресами в базе.
+    output = re.sub(r"\x1b\[[0-9;]*m", "", output)
+
     recap = output.split("PLAY RECAP", 1)[1]
     for line in recap.splitlines():
         line = line.strip()


### PR DESCRIPTION
## Summary
- strip ANSI color codes before parsing `PLAY RECAP` so host IPs are stored correctly

## Testing
- `python -m py_compile api/hosts.py`
- `python - <<'PY'
from api.hosts import parse_playbook_summary
out = 'PLAY RECAP \n\x1b[0;32m10.19.1.252\x1b[0m : ok=1 failed=0 unreachable=0\n'
print(parse_playbook_summary(out))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a57986217c8327b5c2cba881c78895