### PR TITLE
Ensure playbook status updates for host IP

### DIFF
--- a/api/hosts.py
+++ b/api/hosts.py
@@ -78,8 +78,12 @@ def run_playbook_async(ip: str) -> None:
             if summary:
                 for host_ip, status in summary.items():
                     set_playbook_status(host_ip, status)
+                if ip not in summary:
+                    status = 'ok' if proc.returncode == 0 else 'failed'
+                    set_playbook_status(ip, status)
             else:
-                set_playbook_status(ip, 'failed')
+                status = 'ok' if proc.returncode == 0 else 'failed'
+                set_playbook_status(ip, status)
         except Exception as e:
             logging.error(f'Ошибка выполнения playbook: {e}')
             set_playbook_status(ip, 'failed')


### PR DESCRIPTION
## Summary
- always store playbook result for the registering host's IP even if Ansible uses hostnames

## Testing
- `python -m py_compile api/hosts.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a57d5899708327bcb5e3092e7e5341