### PR TITLE
Normalize ansible success status

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -163,7 +163,9 @@ def get_ansible_mark(ip: str):
         if result.returncode == 0:
             try:
                 data = json.loads(result.stdout)
-                data['status'] = data.get('status', 'ok') or 'ok'
+                data['status'] = (data.get('status', 'ok') or 'ok').lower()
+                if data['status'] == 'success':
+                    data['status'] = 'ok'
                 # Once the mark file is successfully read we assume the
                 # playbook finished and update the stored status so that
                 # subsequent calls don't fall back to "running" when the host


### PR DESCRIPTION
## Summary
- normalize ansible mark status to handle 'success' value

## Testing
- `python -m py_compile services/__init__.py web/__init__.py api/ansible.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a57d5899708327bcb5e3092e7e5341