### PR TITLE
Poll remote install status

### DIFF
--- a/api/ansible.py
+++ b/api/ansible.py
@@ -15,7 +15,7 @@ from config import (
 from . import api_bp
 from services import (
     list_files_in_dir,
-    get_ansible_mark,
+    get_install_status,
     create_file_api_handlers,
 )
 
@@ -84,7 +84,7 @@ def api_ansible_templates_list():
 
 @api_bp.route('/ansible/status/<ip>', methods=['GET'])
 def api_ansible_status(ip: str):
-    result = get_ansible_mark(ip)
+    result = get_install_status(ip)
     return jsonify(result)
 
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -4,9 +4,11 @@ import subprocess
 import datetime
 import logging
 import re
+import json
 
 from db_utils import get_db
 from services import set_playbook_status
+from config import SSH_PASSWORD, SSH_USER, SSH_OPTIONS
 
 # Ensure background threads start only once
 _tasks_started = False
@@ -103,6 +105,56 @@ def ansible_log_monitor() -> None:
             time.sleep(5)
 
 
+def fetch_install_status(ip: str) -> None:
+    """Считать удалённый файл install_status.json и сохранить его в БД."""
+    cmd = (
+        f"sshpass -p '{SSH_PASSWORD}' ssh {SSH_OPTIONS} {SSH_USER}@{ip} "
+        "'cat /var/log/install_status.json'"
+    )
+    try:
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0:
+            if "No such file" not in result.stderr:
+                logging.debug(
+                    f"install_status.json недоступен на {ip}: {result.stderr.strip()}"
+                )
+            return
+        data = json.loads(result.stdout)
+        status = data.get('status')
+        completed_at = data.get('completed_at')
+        if status and completed_at:
+            set_playbook_status(ip, status, completed_at)
+    except json.JSONDecodeError as e:
+        logging.warning(f"Некорректный JSON от {ip}: {e}")
+    except subprocess.TimeoutExpired:
+        logging.warning(f"Таймаут получения install_status.json от {ip}")
+    except Exception as e:
+        logging.warning(f"Ошибка при чтении install_status.json с {ip}: {e}")
+
+
+def install_status_monitor() -> None:
+    """Периодически проверять наличие install_status.json на хостах."""
+    while True:
+        time.sleep(60)
+        logging.info("Проверка статуса установки на хостах...")
+        try:
+            with get_db() as db:
+                rows = db.execute(
+                    "SELECT DISTINCT ip FROM hosts WHERE ip != '—' AND ip IS NOT NULL"
+                ).fetchall()
+                ips = [row[0] for row in rows]
+            for ip in ips:
+                fetch_install_status(ip)
+                time.sleep(0.1)
+        except Exception as e:
+            logging.error(
+                f"Ошибка в фоновой задаче проверки install_status.json: {e}",
+                exc_info=True,
+            )
+
+
 def start_background_tasks() -> None:
     """Start all background threads."""
     global _tasks_started
@@ -111,3 +163,4 @@ def start_background_tasks() -> None:
     _tasks_started = True
     threading.Thread(target=ping_hosts_background, daemon=True).start()
     threading.Thread(target=ansible_log_monitor, daemon=True).start()
+    threading.Thread(target=install_status_monitor, daemon=True).start()

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from config import LOCAL_OFFSET, ANSIBLE_FILES_DIR
 from db_utils import get_db
-from services import get_ansible_mark, sync_inventory_hosts
+from services import get_install_status, sync_inventory_hosts
 
 web_bp = Blueprint('web', __name__)
 
@@ -41,11 +41,11 @@ def dashboard():
         mac, ip, stage, details, ts_utc, ipxe_utc, db_is_online = row
         last_seen = datetime.datetime.fromisoformat(ts_utc) + LOCAL_OFFSET
         is_online = bool(db_is_online)
-        ansible_result = get_ansible_mark(ip)
-        ansible_status = ansible_result.get('status')
-        if ansible_status == 'ok':
+        install_result = get_install_status(ip)
+        install_status = install_result.get('status')
+        if install_status == 'completed':
             try:
-                install_date_str = ansible_result['install_date']
+                install_date_str = install_result['install_date']
                 install_dt = datetime.datetime.fromisoformat(
                     install_date_str.replace('Z', '+00:00')
                 )
@@ -55,18 +55,17 @@ def dashboard():
                     datetime.timezone.utc
                 ) + LOCAL_OFFSET
                 date_str = install_dt.strftime('%d.%m.%Y %H:%M')
-                version = ansible_result.get('version', '')
-                stage_label = f'✅ Ansible: {date_str}'
-                if version:
-                    stage_label += f' (v{version})'
+                stage_label = f'✅ Установка: {date_str}'
             except Exception as e:
                 logging.warning(
-                    f"Ошибка парсинга даты в ansible_mark.json для {ip}: {e}"
+                    f"Ошибка парсинга даты install_status.json для {ip}: {e}"
                 )
-                stage_label = '✅ Ansible: завершён (дата неизвестна)'
-        elif ansible_status == 'pending':
-            label = STAGE_LABELS.get(stage, '—') + ' ⏳ Ansible: в процессе'
-            date_str = ansible_result.get('install_date')
+                stage_label = '✅ Установка: завершена'
+        elif install_status == 'failed':
+            stage_label = '❌ Установка: ошибка'
+        elif install_status == 'pending':
+            label = STAGE_LABELS.get(stage, '—') + ' ⏳ Установка: в процессе'
+            date_str = install_result.get('install_date')
             if date_str:
                 try:
                     install_dt = datetime.datetime.fromisoformat(
@@ -94,9 +93,9 @@ def dashboard():
         total_hosts += 1
         if is_online:
             online_count += 1
-        if stage == 'debian_install' or ansible_status == 'pending':
+        if stage == 'debian_install' or install_status == 'pending':
             installing_count += 1
-        if ansible_status == 'ok':
+        if install_status == 'completed':
             completed_count += 1
     return render_template(
         'dashboard.html',


### PR DESCRIPTION
## Summary
- Poll each host every minute for `/var/log/install_status.json` and record completion timestamp and status
- Track and expose install status through updated service helpers and REST API
- Display install progress and completion time on dashboard

## Testing
- `python -m py_compile services/__init__.py tasks/__init__.py web/__init__.py api/ansible.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6cf5e217483278b313773371dae3f