### PR TITLE
Poll hosts for installation status

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -55,4 +55,15 @@ def get_db():
         """
     )
 
+    # Status of OS installation completion
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS install_status (
+            ip TEXT PRIMARY KEY,
+            status TEXT,
+            completed_at TEXT
+        )
+        """
+    )
+
     return conn

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -132,6 +132,53 @@ def set_playbook_status(ip: str, status: str) -> None:
     except Exception as e:
         logging.error(f"Ошибка обновления статуса playbook для {ip}: {e}")
 
+
+def set_install_status(ip: str, status: str, completed_at: str) -> None:
+    """Сохранить статус установки ОС для указанного IP."""
+    try:
+        with get_db() as db:
+            db.execute(
+                """
+                INSERT INTO install_status (ip, status, completed_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(ip) DO UPDATE SET
+                    status = excluded.status,
+                    completed_at = excluded.completed_at
+                """,
+                (ip, status, completed_at),
+            )
+    except Exception as e:
+        logging.error(f"Ошибка обновления install_status для {ip}: {e}")
+
+
+def check_install_status(ip: str) -> None:
+    """Проверить наличие ``install_status.json`` на хосте и сохранить результат."""
+    if not re.match(r'^\d{1,3}(\.\d{1,3}){3}$', ip) or ip == '—':
+        return
+    cmd = (
+        f"sshpass -p '{SSH_PASSWORD}' ssh {SSH_OPTIONS} {SSH_USER}@{ip} "
+        "'cat /var/log/install_status.json'"
+    )
+    try:
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0:
+            try:
+                data = json.loads(result.stdout)
+                status = data.get('status')
+                completed_at = data.get('completed_at')
+                if status and completed_at:
+                    set_install_status(ip, status.lower(), completed_at)
+            except json.JSONDecodeError as e:
+                logging.warning(
+                    f"Некорректный JSON install_status на {ip}: {e}"
+                )
+    except subprocess.TimeoutExpired:
+        logging.warning(f"Таймаут проверки install_status на {ip}")
+    except Exception as e:
+        logging.warning(f"Ошибка проверки install_status на {ip}: {e}")
+
 def get_ansible_mark(ip: str):
     """Fetch ``/opt/ansible_mark.json`` or fall back to stored status.
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -17,9 +17,12 @@ def dashboard():
                (SELECT ts FROM hosts
                 WHERE mac = h.mac AND stage IN ('dhcp', 'ipxe_started')
                 ORDER BY ts ASC LIMIT 1) AS ipxe_ts,
-               COALESCE(s.is_online, 0) AS is_online
+               COALESCE(s.is_online, 0) AS is_online,
+               i.status AS install_status,
+               i.completed_at AS install_completed
         FROM hosts h
         LEFT JOIN host_status s ON h.ip = s.ip
+        LEFT JOIN install_status i ON h.ip = i.ip
         INNER JOIN (
             SELECT mac, MAX(ts) AS last_ts FROM hosts GROUP BY mac
         ) grp
@@ -30,7 +33,8 @@ def dashboard():
         'dhcp': 'IP получен',
         'ipxe_started': 'Загрузка iPXE',
         'debian_install': 'Идёт установка',
-        'reboot': 'Перезагрузка'
+        'reboot': 'Перезагрузка',
+        'completed': 'Установка завершена'
     }
     hosts = []
     total_hosts = 0
@@ -38,9 +42,36 @@ def dashboard():
     installing_count = 0
     completed_count = 0
     for row in rows:
-        mac, ip, stage, details, ts_utc, ipxe_utc, db_is_online = row
+        (
+            mac,
+            ip,
+            stage,
+            details,
+            ts_utc,
+            ipxe_utc,
+            db_is_online,
+            install_status,
+            install_completed,
+        ) = row
         last_seen = datetime.datetime.fromisoformat(ts_utc) + LOCAL_OFFSET
         is_online = bool(db_is_online)
+
+        stage_label = STAGE_LABELS.get(stage, '—')
+        if install_status == 'completed':
+            try:
+                install_dt = datetime.datetime.fromisoformat(
+                    install_completed.replace('Z', '+00:00')
+                )
+                if install_dt.tzinfo is None:
+                    install_dt = install_dt.replace(tzinfo=datetime.timezone.utc)
+                install_dt = install_dt.astimezone(
+                    datetime.timezone.utc
+                ) + LOCAL_OFFSET
+                date_str = install_dt.strftime('%d.%m.%Y %H:%M')
+                stage_label = f'✅ Установка: {date_str}'
+            except Exception:
+                stage_label = '✅ Установка: завершена'
+
         ansible_result = get_ansible_mark(ip)
         ansible_status = ansible_result.get('status')
         if ansible_status == 'ok':
@@ -65,7 +96,7 @@ def dashboard():
                 )
                 stage_label = '✅ Ansible: завершён (дата неизвестна)'
         elif ansible_status == 'pending':
-            label = STAGE_LABELS.get(stage, '—') + ' ⏳ Ansible: в процессе'
+            label = stage_label + ' ⏳ Ansible: в процессе'
             date_str = ansible_result.get('install_date')
             if date_str:
                 try:
@@ -81,8 +112,7 @@ def dashboard():
                 except Exception:
                     pass
             stage_label = label
-        else:
-            stage_label = STAGE_LABELS.get(stage, '—')
+
         hosts.append({
             'mac': mac,
             'ip': ip or '—',
@@ -94,10 +124,10 @@ def dashboard():
         total_hosts += 1
         if is_online:
             online_count += 1
-        if stage == 'debian_install' or ansible_status == 'pending':
-            installing_count += 1
-        if ansible_status == 'ok':
+        if install_status == 'completed':
             completed_count += 1
+        else:
+            installing_count += 1
     return render_template(
         'dashboard.html',
         hosts=hosts,


### PR DESCRIPTION
## Summary
- track OS installation completion per host in new `install_status` table
- poll hosts every minute for `/var/log/install_status.json` and record results
- show installation completion time on dashboard and update stats

## Testing
- `python -m py_compile db_utils.py services/__init__.py tasks/__init__.py web/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6cf5e217483278b313773371dae3f