### PR TITLE
feat: monitor install status

### DIFF
--- a/api/ansible.py
+++ b/api/ansible.py
@@ -15,7 +15,7 @@ from config import (
 from . import api_bp
 from services import (
     list_files_in_dir,
-    get_ansible_mark,
+    get_install_status,
     create_file_api_handlers,
 )
 
@@ -82,9 +82,10 @@ def api_ansible_templates_list():
         logging.error(f"Ошибка при получении списка шаблонов: {e}")
         return jsonify({'error': str(e)}), 500
 
-@api_bp.route('/ansible/status/<ip>', methods=['GET'])
-def api_ansible_status(ip: str):
-    result = get_ansible_mark(ip)
+@api_bp.route('/install/status/<ip>', methods=['GET'])
+def api_install_status(ip: str):
+    """Return stored installation status for host."""
+    result = get_install_status(ip)
     return jsonify(result)
 
 

--- a/db_utils.py
+++ b/db_utils.py
@@ -55,4 +55,16 @@ def get_db():
         """
     )
 
+    # Installation status reported by target hosts
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS install_status (
+            ip TEXT PRIMARY KEY,
+            status TEXT,
+            completed_at TEXT,
+            updated TEXT
+        )
+        """
+    )
+
     return conn

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from config import LOCAL_OFFSET, ANSIBLE_FILES_DIR
 from db_utils import get_db
-from services import get_ansible_mark, sync_inventory_hosts
+from services import get_install_status, sync_inventory_hosts
 
 web_bp = Blueprint('web', __name__)
 
@@ -41,11 +41,11 @@ def dashboard():
         mac, ip, stage, details, ts_utc, ipxe_utc, db_is_online = row
         last_seen = datetime.datetime.fromisoformat(ts_utc) + LOCAL_OFFSET
         is_online = bool(db_is_online)
-        ansible_result = get_ansible_mark(ip)
-        ansible_status = ansible_result.get('status')
-        if ansible_status == 'ok':
+        install_result = get_install_status(ip)
+        install_status = install_result.get('status')
+        if install_status == 'completed':
             try:
-                install_date_str = ansible_result['install_date']
+                install_date_str = install_result.get('install_date')
                 install_dt = datetime.datetime.fromisoformat(
                     install_date_str.replace('Z', '+00:00')
                 )
@@ -55,32 +55,16 @@ def dashboard():
                     datetime.timezone.utc
                 ) + LOCAL_OFFSET
                 date_str = install_dt.strftime('%d.%m.%Y %H:%M')
-                version = ansible_result.get('version', '')
-                stage_label = f'✅ Ansible: {date_str}'
-                if version:
-                    stage_label += f' (v{version})'
+                stage_label = f'✅ Установка: {date_str}'
             except Exception as e:
                 logging.warning(
-                    f"Ошибка парсинга даты в ansible_mark.json для {ip}: {e}"
+                    f"Ошибка парсинга даты установки для {ip}: {e}"
                 )
-                stage_label = '✅ Ansible: завершён (дата неизвестна)'
-        elif ansible_status == 'pending':
-            label = STAGE_LABELS.get(stage, '—') + ' ⏳ Ansible: в процессе'
-            date_str = ansible_result.get('install_date')
-            if date_str:
-                try:
-                    install_dt = datetime.datetime.fromisoformat(
-                        date_str.replace('Z', '+00:00')
-                    )
-                    if install_dt.tzinfo is None:
-                        install_dt = install_dt.replace(tzinfo=datetime.timezone.utc)
-                    install_dt = install_dt.astimezone(
-                        datetime.timezone.utc
-                    ) + LOCAL_OFFSET
-                    label += ' с ' + install_dt.strftime('%d.%m.%Y %H:%M')
-                except Exception:
-                    pass
-            stage_label = label
+                stage_label = '✅ Установка: завершена (дата неизвестна)'
+        elif install_status == 'pending':
+            stage_label = STAGE_LABELS.get(stage, '—') + ' ⏳ Установка: в процессе'
+        elif install_status == 'failed':
+            stage_label = '❌ Установка: ошибка'
         else:
             stage_label = STAGE_LABELS.get(stage, '—')
         hosts.append({
@@ -94,9 +78,9 @@ def dashboard():
         total_hosts += 1
         if is_online:
             online_count += 1
-        if stage == 'debian_install' or ansible_status == 'pending':
+        if stage == 'debian_install' or install_status == 'pending':
             installing_count += 1
-        if ansible_status == 'ok':
+        if install_status == 'completed':
             completed_count += 1
     return render_template(
         'dashboard.html',


### PR DESCRIPTION
## Summary
- persist install status for hosts
- background task polls targets for install status
- dashboard and API surface installation status

## Testing
- `python -m py_compile db_utils.py services/__init__.py tasks/__init__.py web/__init__.py api/ansible.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6cf5e217483278b313773371dae3f