### PR TITLE
Normalize install status values

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -162,7 +162,9 @@ def get_install_status(ip: str):
                 (ip,),
             ).fetchone()
         if row:
-            return {'status': row['status'], 'install_date': row['completed_at']}
+            status = (row['status'] or '').strip().lower()
+            completed_at = (row['completed_at'] or '').strip() or None
+            return {'status': status or 'pending', 'install_date': completed_at}
         return {'status': 'pending'}
     except Exception as e:
         logging.error(f"Ошибка получения статуса установки для {ip}: {e}")

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -118,8 +118,8 @@ def fetch_install_status(ip: str) -> None:
         if result.returncode == 0:
             try:
                 data = json.loads(result.stdout or '{}')
-                status = (data.get('status') or '').lower()
-                completed_at = data.get('completed_at')
+                status = (data.get('status') or '').strip().lower()
+                completed_at = (data.get('completed_at') or '').strip() or None
                 if status:
                     set_install_status(ip, status, completed_at)
                 else:


### PR DESCRIPTION
## Summary
- Trim whitespace and normalize case when retrieving install status JSON
- Sanitize stored installation status values on read

## Testing
- `python -m py_compile tasks/__init__.py services/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6d3a49d3c832799a8ded5da855df4