### PR TITLE
fix: always fetch install status from host

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -154,7 +154,53 @@ def set_install_status(ip: str, status: str, completed_at: Optional[str]) -> Non
 
 
 def get_install_status(ip: str):
-    """Получить сохранённый статус установки из базы."""
+    """Получить текущий статус установки с удалённого хоста.
+
+    При каждом запросе выполняет попытку чтения ``/var/log/install_status.json``
+    по SSH.  Полученный статус сохраняется в локальной БД и возвращается
+    вызывающему коду.  Если чтение файла не удалось, используется последняя
+    сохранённая запись из базы данных, либо ``pending``.
+    """
+
+    cmd = (
+        f"sshpass -p '{SSH_PASSWORD}' ssh {SSH_OPTIONS} {SSH_USER}@{ip} "
+        "'cat /var/log/install_status.json'"
+    )
+    try:
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0:
+            try:
+                data = json.loads(result.stdout or '{}')
+                status = (data.get('status') or '').strip().lower()
+                completed_at = (data.get('completed_at') or '').strip() or None
+                if status:
+                    try:
+                        set_install_status(ip, status, completed_at)
+                    except Exception as e:
+                        logging.warning(
+                            f"Не удалось сохранить статус установки для {ip}: {e}"
+                        )
+                    return {'status': status, 'install_date': completed_at}
+                logging.warning(f"Пустой статус установки от {ip}")
+            except json.JSONDecodeError as e:
+                logging.warning(
+                    f"Некорректный JSON install_status от {ip}: {e}"
+                )
+        else:
+            if 'No such file' in (result.stderr or ''):
+                set_install_status(ip, 'pending', None)
+                return {'status': 'pending'}
+            logging.warning(
+                f"SSH ошибка при получении install_status от {ip}: {result.stderr.strip()}"
+            )
+    except subprocess.TimeoutExpired:
+        logging.warning(f"Таймаут при получении install_status от {ip}")
+    except Exception as e:
+        logging.error(f"Ошибка при получении install_status от {ip}: {e}")
+
+    # Фолбэк: возвращаем последнее сохранённое значение из базы
     try:
         with get_db() as db:
             row = db.execute(


### PR DESCRIPTION
## Summary
- fetch `/var/log/install_status.json` over SSH on every request
- fall back to cached DB entry when remote read fails

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6d7158d7c8327836ae2d744a71cba