### PR TITLE
Handle install completion without explicit status

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -175,6 +175,9 @@ def get_install_status(ip: str):
                 data = json.loads(result.stdout or '{}')
                 status = (data.get('status') or '').strip().lower()
                 completed_at = (data.get('completed_at') or '').strip() or None
+                if not status and data:
+                    # Treat any JSON content as a completed installation
+                    status = 'completed'
                 if status:
                     try:
                         set_install_status(ip, status, completed_at)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -120,6 +120,9 @@ def fetch_install_status(ip: str) -> None:
                 data = json.loads(result.stdout or '{}')
                 status = (data.get('status') or '').strip().lower()
                 completed_at = (data.get('completed_at') or '').strip() or None
+                if not status and data:
+                    # The presence of any JSON is treated as completion
+                    status = 'completed'
                 if status:
                     set_install_status(ip, status, completed_at)
                 else:


### PR DESCRIPTION
## Summary
- Mark hosts as completed when install_status.json contains any JSON
- Apply same fallback for on-demand install status fetches

## Testing
- `python -m py_compile services/__init__.py tasks/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6dfb42c988327a6eb77a089ad968f