### PR TITLE
Simplify dashboard and remove status tracking

### DIFF
--- a/api/ansible.py
+++ b/api/ansible.py
@@ -4,8 +4,6 @@ import subprocess
 import logging
 import re
 
-from db_utils import get_db
-
 from config import (
     ANSIBLE_PLAYBOOK,
     ANSIBLE_INVENTORY,
@@ -15,7 +13,6 @@ from config import (
 from . import api_bp
 from services import (
     list_files_in_dir,
-    get_install_status,
     create_file_api_handlers,
 )
 
@@ -81,13 +78,6 @@ def api_ansible_templates_list():
     except Exception as e:
         logging.error(f"Ошибка при получении списка шаблонов: {e}")
         return jsonify({'error': str(e)}), 500
-
-@api_bp.route('/install/status/<ip>', methods=['GET'])
-def api_install_status(ip: str):
-    """Return stored installation status for host."""
-    result = get_install_status(ip)
-    return jsonify(result)
-
 
 @api_bp.route('/logs/ansible', methods=['GET'])
 def api_logs_ansible():

--- a/db_utils.py
+++ b/db_utils.py
@@ -19,7 +19,7 @@ def get_db():
     conn = sqlite3.connect(DB_PATH, detect_types=sqlite3.PARSE_DECLTYPES)
     conn.row_factory = sqlite3.Row
 
-    # Table with host info and current installation stage
+    # Table with host info
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS hosts (
@@ -33,35 +33,12 @@ def get_db():
         """
     )
 
-    # Store ping results to track host online status
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS host_status (
-            ip TEXT PRIMARY KEY,
-            is_online BOOLEAN,
-            last_checked TEXT
-        )
-        """
-    )
-
     # Status of Ansible playbook execution
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS playbook_status (
             ip TEXT PRIMARY KEY,
             status TEXT,
-            updated TEXT
-        )
-        """
-    )
-
-    # Installation status reported by target hosts
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS install_status (
-            ip TEXT PRIMARY KEY,
-            status TEXT,
-            completed_at TEXT,
             updated TEXT
         )
         """

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -117,14 +117,6 @@
     .btn-logtail:hover { background: #7b1fa2; }
     .btn-logtail i { font-size: 0.9em; }
     .container { padding: 24px; }
-    .stats-container { display: flex; gap: 16px; margin-bottom: 24px; flex-wrap: wrap; }
-    .stat-card { flex: 1; min-width: 120px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 16px; text-align: center; box-shadow: var(--table-shadow); }
-    .stat-number { font-size: 1.8em; font-weight: 700; margin-bottom: 4px; }
-    .stat-label { font-size: 0.85em; font-weight: 600; color: var(--grey); letter-spacing: 1px; }
-    .stat-card.total .stat-number { color: var(--accent); }
-    .stat-card.online .stat-number { color: var(--green); }
-    .stat-card.installing .stat-number { color: var(--orange); }
-    .stat-card.completed .stat-number { color: var(--green); }
     table {
       width: 100%;
       border-collapse: collapse;
@@ -145,12 +137,6 @@
     @media (prefers-color-scheme: dark) {
       tr:hover { background-color: rgba(255,255,255,0.05); }
     }
-    .status { font-weight: 600; display: flex; align-items: center; gap: 6px; }
-    .status.online { color: var(--green); }
-    .status.offline { color: var(--grey); }
-    .status.running { color: var(--orange); }
-    .status.failed { color: var(--danger); }
-    .status.unknown { color: var(--grey); }
     #overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: none; z-index: 1000; }
     .modal { position: fixed; top: 0; right: 0; width: 50vw; height: 100vh; background: var(--bg); z-index: 1001; display: none; flex-direction: column; box-shadow: -4px 0 12px rgba(0,0,0,0.3); }
     .modal header { background: var(--accent); color: #fff; padding: 10px 16px; display: flex; justify-content: space-between; align-items: center; flex-shrink: 0; }

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,69 +1,13 @@
 import threading
 import time
 import subprocess
-import datetime
 import logging
 import re
-import json
 
-from db_utils import get_db
-from services import set_playbook_status, set_install_status
-from config import SSH_PASSWORD, SSH_USER, SSH_OPTIONS
+from services import set_playbook_status
 
 # Ensure background threads start only once
 _tasks_started = False
-
-
-def ping_host(ip: str) -> bool:
-    """Ping host and return True if reachable."""
-    try:
-        result = subprocess.run(
-            ['ping', '-c', '1', '-W', '1', ip],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        return result.returncode == 0
-    except Exception as e:
-        logging.warning(f"Ошибка при пинге {ip}: {e}")
-        return False
-
-
-def update_host_online_status(ip: str, is_online: bool) -> None:
-    """Update online status for host in database."""
-    try:
-        with get_db() as db:
-            db.execute(
-                '''
-                INSERT INTO host_status (ip, is_online, last_checked)
-                VALUES (?, ?, ?)
-                ON CONFLICT(ip) DO UPDATE SET
-                    is_online = excluded.is_online,
-                    last_checked = excluded.last_checked
-                ''',
-                (ip, is_online, datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')),
-            )
-    except Exception as e:
-        logging.error(f"Ошибка обновления статуса для {ip}: {e}")
-
-
-def ping_hosts_background():
-    """Background task that periodically pings all known hosts."""
-    while True:
-        time.sleep(60)
-        logging.info("Начинаем фоновый пинг хостов...")
-        try:
-            with get_db() as db:
-                rows = db.execute(
-                    "SELECT DISTINCT ip FROM hosts WHERE ip != '—' AND ip IS NOT NULL"
-                ).fetchall()
-                ips = [row[0] for row in rows]
-            for ip in ips:
-                is_online = ping_host(ip)
-                update_host_online_status(ip, is_online)
-                time.sleep(0.1)
-            logging.info(f"Фоновый пинг завершён. Проверено {len(ips)} хостов.")
-        except Exception as e:
-            logging.error(f"Ошибка в фоновой задаче пинга: {e}", exc_info=True)
 
 
 def ansible_log_monitor() -> None:
@@ -105,74 +49,10 @@ def ansible_log_monitor() -> None:
             time.sleep(5)
 
 
-def fetch_install_status(ip: str) -> None:
-    """Retrieve install_status.json from host and store it."""
-    cmd = (
-        f"sshpass -p '{SSH_PASSWORD}' ssh {SSH_OPTIONS} {SSH_USER}@{ip} "
-        "'cat /var/log/install_status.json'"
-    )
-    try:
-        result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=10
-        )
-        if result.returncode == 0:
-            try:
-                data = json.loads(result.stdout or '{}')
-                status = (data.get('status') or '').strip().lower()
-                completed_at = (data.get('completed_at') or '').strip() or None
-                if not status and data:
-                    # The presence of any JSON is treated as completion
-                    status = 'completed'
-                if status:
-                    set_install_status(ip, status, completed_at)
-                else:
-                    logging.warning(f"Пустой статус установки от {ip}")
-            except json.JSONDecodeError as e:
-                logging.warning(
-                    f"Некорректный JSON install_status от {ip}: {e}"
-                )
-        else:
-            if 'No such file' in result.stderr:
-                set_install_status(ip, 'pending', None)
-            else:
-                logging.warning(
-                    f"SSH ошибка при получении install_status от {ip}: {result.stderr.strip()}"
-                )
-    except subprocess.TimeoutExpired:
-        logging.warning(f"Таймаут при получении install_status от {ip}")
-    except Exception as e:
-        logging.error(f"Ошибка при получении install_status от {ip}: {e}")
-
-
-def install_status_monitor() -> None:
-    """Background task that checks install_status.json on hosts."""
-    while True:
-        time.sleep(60)
-        logging.info("Проверяем статусы установки на хостах...")
-        try:
-            with get_db() as db:
-                rows = db.execute(
-                    "SELECT DISTINCT ip FROM hosts WHERE ip != '—' AND ip IS NOT NULL"
-                ).fetchall()
-                ips = [row[0] for row in rows]
-            for ip in ips:
-                fetch_install_status(ip)
-                time.sleep(0.1)
-            logging.info(
-                f"Проверка статусов установки завершена. Проверено {len(ips)} хостов."
-            )
-        except Exception as e:
-            logging.error(
-                f"Ошибка в задаче мониторинга статуса установки: {e}", exc_info=True
-            )
-
-
 def start_background_tasks() -> None:
     """Start all background threads."""
     global _tasks_started
     if _tasks_started:
         return
     _tasks_started = True
-    threading.Thread(target=ping_hosts_background, daemon=True).start()
     threading.Thread(target=ansible_log_monitor, daemon=True).start()
-    threading.Thread(target=install_status_monitor, daemon=True).start()

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -59,32 +59,12 @@
     <div class="log-viewer" id="ansible-log"></div>
   </div>
   <div class="container">
-    <div class="stats-container">
-      <div class="stat-card total">
-        <div class="stat-number">{{ total_hosts }}</div>
-        <div class="stat-label">TOTAL HOSTS</div>
-      </div>
-      <div class="stat-card online">
-        <div class="stat-number">{{ online_hosts }}</div>
-        <div class="stat-label">ONLINE</div>
-      </div>
-      <div class="stat-card installing">
-        <div class="stat-number">{{ installing_hosts }}</div>
-        <div class="stat-label">INSTALLING</div>
-      </div>
-      <div class="stat-card completed">
-        <div class="stat-number">{{ completed_hosts }}</div>
-        <div class="stat-label">COMPLETED</div>
-      </div>
-    </div>
     <table>
       <thead>
         <tr>
           <th>MAC</th>
           <th>IP</th>
-          <th>Статус</th>
           <th>Last Seen</th>
-          <th>Состояние</th>
           <th>GUI</th>
           <th>Действия</th>
         </tr>
@@ -94,12 +74,7 @@
         <tr data-ip="{{ h.ip }}" data-mac="{{ h.mac }}">
           <td>{{ h.mac }}</td>
           <td>{{ h.ip }}</td>
-          <td>{{ h.stage }}</td>
           <td><time datetime="{{ h.last }}">{{ h.last }}</time></td>
-          <td class="status {{ 'online' if h.online else 'offline' }}">
-            <i class="fa fa-circle"></i>
-            <span>{{ 'Online' if h.online else 'Offline' }}</span>
-          </td>
           <td>
             <a class="btn-portainer portainer-link" href="http://{{ h.ip }}:9000" target="_blank" rel="noopener noreferrer" title="Portainer" style="display: {% if h.ip and h.ip != '—' %}inline-flex{% else %}none{% endif %};">
               <i class="fab fa-docker"></i> Portainer

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,10 +1,9 @@
 from flask import Blueprint, render_template
 import datetime
-import logging
 
 from config import LOCAL_OFFSET, ANSIBLE_FILES_DIR
 from db_utils import get_db
-from services import get_install_status, sync_inventory_hosts
+from services import sync_inventory_hosts
 
 web_bp = Blueprint('web', __name__)
 
@@ -13,82 +12,24 @@ def dashboard():
     sync_inventory_hosts()
     db = get_db()
     rows = db.execute('''
-        SELECT h.mac, h.ip, h.stage, h.details, h.ts,
-               (SELECT ts FROM hosts
-                WHERE mac = h.mac AND stage IN ('dhcp', 'ipxe_started')
-                ORDER BY ts ASC LIMIT 1) AS ipxe_ts,
-               COALESCE(s.is_online, 0) AS is_online
+        SELECT h.mac, h.ip, h.ts
         FROM hosts h
-        LEFT JOIN host_status s ON h.ip = s.ip
         INNER JOIN (
             SELECT mac, MAX(ts) AS last_ts FROM hosts GROUP BY mac
         ) grp
         ON h.mac = grp.mac AND h.ts = grp.last_ts
-        ORDER BY ipxe_ts DESC
+        ORDER BY ts DESC
     ''').fetchall()
-    STAGE_LABELS = {
-        'dhcp': 'IP получен',
-        'ipxe_started': 'Загрузка iPXE',
-        'debian_install': 'Идёт установка',
-        'reboot': 'Перезагрузка'
-    }
     hosts = []
-    total_hosts = 0
-    online_count = 0
-    installing_count = 0
-    completed_count = 0
-    for row in rows:
-        mac, ip, stage, details, ts_utc, ipxe_utc, db_is_online = row
+    for mac, ip, ts_utc in rows:
         last_seen = datetime.datetime.fromisoformat(ts_utc) + LOCAL_OFFSET
-        is_online = bool(db_is_online)
-        install_result = get_install_status(ip)
-        install_status = install_result.get('status')
-        if install_status == 'completed':
-            try:
-                install_date_str = install_result.get('install_date')
-                install_dt = datetime.datetime.fromisoformat(
-                    install_date_str.replace('Z', '+00:00')
-                )
-                if install_dt.tzinfo is None:
-                    install_dt = install_dt.replace(tzinfo=datetime.timezone.utc)
-                install_dt = install_dt.astimezone(
-                    datetime.timezone.utc
-                ) + LOCAL_OFFSET
-                date_str = install_dt.strftime('%d.%m.%Y %H:%M')
-                stage_label = f'✅ Установка: {date_str}'
-            except Exception as e:
-                logging.warning(
-                    f"Ошибка парсинга даты установки для {ip}: {e}"
-                )
-                stage_label = '✅ Установка: завершена (дата неизвестна)'
-        elif install_status == 'pending':
-            stage_label = STAGE_LABELS.get(stage, '—') + ' ⏳ Установка: в процессе'
-        elif install_status == 'failed':
-            stage_label = '❌ Установка: ошибка'
-        else:
-            stage_label = STAGE_LABELS.get(stage, '—')
         hosts.append({
             'mac': mac,
             'ip': ip or '—',
-            'stage': stage_label,
             'last': last_seen.strftime('%H:%M:%S'),
-            'online': is_online,
-            'details': details or '',
         })
-        total_hosts += 1
-        if is_online:
-            online_count += 1
-        if stage == 'debian_install' or install_status == 'pending':
-            installing_count += 1
-        if install_status == 'completed':
-            completed_count += 1
     return render_template(
         'dashboard.html',
         hosts=hosts,
-        stage_labels=STAGE_LABELS,
         ansible_files_path=ANSIBLE_FILES_DIR,
-        total_hosts=total_hosts,
-        online_hosts=online_count,
-        installing_hosts=installing_count,
-        completed_hosts=completed_count,
     )


### PR DESCRIPTION
## Summary
- Remove host count cards and status columns from dashboard
- Drop online/install status tracking and related database tables and tasks
- Clean up API to eliminate install status endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6e4798bf883279325d4fb4124eecb