### PR TITLE
Add remote install status check

### DIFF
--- a/api/hosts.py
+++ b/api/hosts.py
@@ -13,7 +13,7 @@ from config import (
 )
 from . import api_bp
 from services.registration import register_host
-from services import set_playbook_status
+from services import set_playbook_status, get_install_status
 
 
 def parse_playbook_summary(output: str) -> dict[str, str]:
@@ -193,3 +193,16 @@ def api_host_shutdown():
         msg = f'Неизвестная ошибка при отправке команды выключения на {ip}: {e}'
         logging.error(msg, exc_info=True)
         return jsonify({'status': 'error', 'msg': msg}), 500
+
+
+@api_bp.route('/host/install_status', methods=['GET'])
+def api_host_install_status():
+    """Return installation status for a host by IP."""
+    ip = request.args.get('ip')
+    if not ip or ip == '—':
+        return jsonify({'status': 'error', 'msg': 'Неверный IP-адрес'}), 400
+    try:
+        return jsonify(get_install_status(ip)), 200
+    except Exception as e:
+        logging.error(f'Ошибка получения install_status для {ip}: {e}')
+        return jsonify({'status': 'error', 'msg': str(e)}), 500

--- a/config.py
+++ b/config.py
@@ -23,3 +23,4 @@ SSH_OPTIONS = os.getenv(
     'SSH_OPTIONS',
     '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 )
+INSTALL_STATUS_PATH = os.getenv('INSTALL_STATUS_PATH', '/var/log/install_status.json')

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -10,6 +10,7 @@ from config import (
     SSH_PASSWORD,
     SSH_USER,
     SSH_OPTIONS,
+    INSTALL_STATUS_PATH,
 )
 from db_utils import get_db
 
@@ -131,6 +132,57 @@ def set_playbook_status(ip: str, status: str) -> None:
     except Exception as e:
         logging.error(f"Ошибка обновления статуса playbook для {ip}: {e}")
 
+
+
+def get_install_status(ip: str):
+    """Fetch remote ``install_status.json`` and update playbook status.
+
+    Returns a dict with at least a ``status`` field. When the file exists and
+    reports ``completed``, the host is marked as ``ok`` in the local database.
+    """
+    if not re.match(r'^\d{1,3}(\.\d{1,3}){3}$', ip) or ip == '—':
+        return {'status': 'error', 'msg': 'Invalid IP'}
+    cmd = (
+        f"sshpass -p '{SSH_PASSWORD}' ssh {SSH_OPTIONS} {SSH_USER}@{ip} "
+        f"'cat {INSTALL_STATUS_PATH}'"
+    )
+    try:
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0:
+            if 'No such file' in result.stderr:
+                return {
+                    'status': 'none',
+                    'msg': 'Файл install_status.json не найден',
+                }
+            return {
+                'status': 'error',
+                'msg': f"SSH ошибка: {result.stderr.strip()}",
+            }
+        data = json.loads(result.stdout)
+        raw_status = (data.get('status') or '').lower()
+        install_date = data.get('completed_at')
+        if raw_status == 'completed':
+            try:
+                set_playbook_status(ip, 'ok')
+            except Exception:
+                logging.exception(
+                    f"Не удалось сохранить статус playbook для {ip}"
+                )
+            return {'status': 'ok', 'install_date': install_date}
+        if raw_status:
+            return {'status': raw_status, 'install_date': install_date}
+        return {'status': 'pending', 'install_date': install_date}
+    except subprocess.TimeoutExpired:
+        return {'status': 'error', 'msg': 'Таймаут подключения к хосту'}
+    except json.JSONDecodeError as e:
+        return {
+            'status': 'error',
+            'msg': f'Некорректный JSON в install_status.json: {str(e)}',
+        }
+    except Exception as e:
+        return {'status': 'error', 'msg': f'Внутренняя ошибка: {str(e)}'}
 
 
 def get_ansible_mark(ip: str):


### PR DESCRIPTION
## Summary
- allow configuring path to `install_status.json`
- add service helper to fetch install status via SSH and update playbook status
- expose `/api/host/install_status` endpoint to query host installation state

## Testing
- `python -m py_compile config.py services/__init__.py api/hosts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6e98eb6b083278d4e69cb6dd0a964