### PR TITLE
Remove install status column and backend

### DIFF
--- a/api/hosts.py
+++ b/api/hosts.py
@@ -13,7 +13,7 @@ from config import (
 )
 from . import api_bp
 from services.registration import register_host
-from services import set_playbook_status, get_install_status
+from services import set_playbook_status
 
 
 def parse_playbook_summary(output: str) -> dict[str, str]:
@@ -195,14 +195,3 @@ def api_host_shutdown():
         return jsonify({'status': 'error', 'msg': msg}), 500
 
 
-@api_bp.route('/host/install_status', methods=['GET'])
-def api_host_install_status():
-    """Return installation status for a host by IP."""
-    ip = request.args.get('ip')
-    if not ip or ip == '—':
-        return jsonify({'status': 'error', 'msg': 'Неверный IP-адрес'}), 400
-    try:
-        return jsonify(get_install_status(ip)), 200
-    except Exception as e:
-        logging.error(f'Ошибка получения install_status для {ip}: {e}')
-        return jsonify({'status': 'error', 'msg': str(e)}), 500

--- a/config.py
+++ b/config.py
@@ -23,4 +23,3 @@ SSH_OPTIONS = os.getenv(
     'SSH_OPTIONS',
     '-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null'
 )
-INSTALL_STATUS_PATH = os.getenv('INSTALL_STATUS_PATH', '/var/log/install_status.json')

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -166,7 +166,3 @@
     .header-group { display: flex; gap: 8px; align-items: center; }
     .divider { width: 1px; height: 24px; background: var(--divider); margin: 0 12px; }
     .actions-cell { display: flex; flex-direction: column; gap: 4px; align-items: flex-start; }
-    .status-ok { color: var(--green); font-weight: 600; }
-    .status-error { color: var(--danger); font-weight: 600; }
-    .status-pending { color: var(--orange); font-weight: 600; }
-    .status-none { color: var(--grey); }

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -46,40 +46,8 @@
             }
         });
     }
-    async function updateInstallStatuses() {
-        const rows = document.querySelectorAll('#hosts-table-body tr');
-        for (const row of rows) {
-            const ip = row.dataset.ip;
-            const cell = row.querySelector('.install-status');
-            if (!cell) continue;
-            if (!ip || ip === '—') {
-                cell.innerHTML = '<span class="status-none">—</span>';
-                continue;
-            }
-            try {
-                const res = await fetch(`/api/host/install_status?ip=${encodeURIComponent(ip)}`);
-                if (!res.ok) throw new Error();
-                const data = await res.json();
-                const st = (data.status || '').toLowerCase();
-                if (st === 'ok') {
-                    cell.innerHTML = '<span class="status-ok">OK</span>';
-                } else if (st === 'error') {
-                    const msg = data.msg ? ` (${data.msg})` : '';
-                    cell.innerHTML = `<span class="status-error">error${msg}</span>`;
-                } else if (st === 'none') {
-                    cell.innerHTML = '<span class="status-none">—</span>';
-                } else {
-                    cell.innerHTML = `<span class="status-pending">${st || 'pending'}</span>`;
-                }
-            } catch (e) {
-                cell.innerHTML = '<span class="status-error">error</span>';
-            }
-        }
-    }
     document.addEventListener('DOMContentLoaded', () => {
         updatePortainerLinks();
-        updateInstallStatuses();
-        setInterval(updateInstallStatuses, 10000);
     });
     async function openModalWithContent(modalId, apiUrl, contentElementId, isPlaybook = false) {
       const modal = document.getElementById(modalId);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -65,7 +65,6 @@
           <th>MAC</th>
           <th>IP</th>
           <th>Last Seen</th>
-          <th>Install</th>
           <th>GUI</th>
           <th>Действия</th>
         </tr>
@@ -76,7 +75,6 @@
           <td>{{ h.mac }}</td>
           <td>{{ h.ip }}</td>
           <td><time datetime="{{ h.last }}">{{ h.last }}</time></td>
-          <td class="install-status"></td>
           <td>
             <a class="btn-portainer portainer-link" href="http://{{ h.ip }}:9000" target="_blank" rel="noopener noreferrer" title="Portainer" style="display: {% if h.ip and h.ip != '—' %}inline-flex{% else %}none{% endif %};">
               <i class="fab fa-docker"></i> Portainer


### PR DESCRIPTION
## Summary
- Drop Install column from dashboard UI
- Delete client-side polling and server endpoint for install status
- Remove related config and CSS styles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a70d3a4a4483278155de5cc42bea8b