### PR TITLE
Fix Logtail link in dashboard template

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -23,7 +23,7 @@
         <a class="btn btn-semaphore" href="http://10.19.1.90:3000" target="_blank" rel="noopener noreferrer">
           <i class="fa fa-external-link-alt"></i> Semaphore
         </a>
-        <a class="btn btn-logtail" href="{{ url_for('logtail.logtail_dashboard') }}" target="_blank" rel="noopener noreferrer">
+        <a class="btn btn-logtail" href="{{ url_for('logtail.dashboard') }}" target="_blank" rel="noopener noreferrer">
           <i class="fas fa-file-alt"></i> Logtail
         </a>
       </div>


### PR DESCRIPTION
## Summary
- fix wrong Logtail dashboard URL in main dashboard template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8015684288327a4961f6b951af4bc