### PR TITLE
Fix log tail stream cancellation

### DIFF
--- a/templates/logtail.html
+++ b/templates/logtail.html
@@ -642,7 +642,7 @@ function switchTab(tabName) {
   } else {
     document.getElementById('journalTab').classList.add('active');
     document.querySelector('.tab-button:nth-child(2)').classList.add('active');
-    if (currentStream) { currentStream.cancel(); currentStream = null; }
+    if (currentStream) { currentStream.abort(); currentStream = null; }
     if (selectedHost) { refreshServiceList(); }
   }
 }
@@ -777,7 +777,7 @@ async function loadColorRules() {
 
 function tail() {
   if (!selectedHost) return;
-  if (currentStream) currentStream.cancel();
+  if (currentStream) currentStream.abort();
   const grep = document.getElementById('grep').value;
   const exclude = document.getElementById('excludePattern').value;
   const level = document.getElementById('logLevel').value;


### PR DESCRIPTION
## Summary
- use `AbortController.abort()` instead of nonexistent `cancel()` when switching or retailing logs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a81703d9b8832780ed43a0cb1c57dd